### PR TITLE
Add tests for Order

### DIFF
--- a/src/main/java/seedu/loyaltylift/model/order/Order.java
+++ b/src/main/java/seedu/loyaltylift/model/order/Order.java
@@ -59,7 +59,6 @@ public class Order {
         return createdDate;
     }
 
-
     /**
      * Returns true if both orders have the same name.
      * This defines a weaker notion of equality between two orders.

--- a/src/main/java/seedu/loyaltylift/model/order/Quantity.java
+++ b/src/main/java/seedu/loyaltylift/model/order/Quantity.java
@@ -5,21 +5,21 @@ import static seedu.loyaltylift.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents an Order's quantity in the address book.
- * Guarantees: immutable; is valid as declared in {@link #isValidQuantity(int)}
+ * Guarantees: immutable; is valid as declared in {@link #isValidQuantity(Integer)}
  */
 public class Quantity {
 
 
     public static final String MESSAGE_CONSTRAINTS =
             "Quantity should be a positive integer";
-    public final int value;
+    public final Integer value;
 
     /**
      * Constructs a {@code Quantity}.
      *
      * @param quantity A valid quantity.
      */
-    public Quantity(int quantity) {
+    public Quantity(Integer quantity) {
         requireNonNull(quantity);
         checkArgument(isValidQuantity(quantity), MESSAGE_CONSTRAINTS);
         value = quantity;
@@ -28,7 +28,7 @@ public class Quantity {
     /**
      * Returns true if a given string is a valid quantity.
      */
-    public static boolean isValidQuantity(int test) {
+    public static boolean isValidQuantity(Integer test) {
         return test > 0;
     }
 
@@ -46,7 +46,7 @@ public class Quantity {
 
     @Override
     public int hashCode() {
-        return Integer.hashCode(value);
+        return value.hashCode();
     }
 
 }

--- a/src/main/java/seedu/loyaltylift/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/loyaltylift/model/util/SampleDataUtil.java
@@ -1,5 +1,6 @@
 package seedu.loyaltylift.model.util;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -12,6 +13,9 @@ import seedu.loyaltylift.model.customer.Customer;
 import seedu.loyaltylift.model.customer.CustomerType;
 import seedu.loyaltylift.model.customer.Email;
 import seedu.loyaltylift.model.customer.Phone;
+import seedu.loyaltylift.model.order.CreatedDate;
+import seedu.loyaltylift.model.order.Quantity;
+import seedu.loyaltylift.model.order.Status;
 import seedu.loyaltylift.model.tag.Tag;
 
 /**
@@ -62,6 +66,27 @@ public class SampleDataUtil {
         return Arrays.stream(strings)
                 .map(Tag::new)
                 .collect(Collectors.toSet());
+    }
+
+    /**
+     * Returns a Quantity from a given string.
+     */
+    public static Quantity getQuantity(String quantity) {
+        return new Quantity(Integer.parseInt(quantity));
+    }
+
+    /**
+     * Returns a Status from a given string.
+     */
+    public static Status getStatus(String status) {
+        return Status.fromString(status);
+    }
+
+    /**
+     * Returns a CreatedDate from a given string.
+     */
+    public static CreatedDate getCreatedDate(String createdDate) {
+        return new CreatedDate(LocalDate.parse(createdDate, CreatedDate.DATE_FORMATTER));
     }
 
 }

--- a/src/test/java/seedu/loyaltylift/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/CommandTestUtil.java
@@ -26,6 +26,9 @@ import seedu.loyaltylift.testutil.EditCustomerDescriptorBuilder;
  * Contains helper methods for testing commands.
  */
 public class CommandTestUtil {
+
+    // customer
+
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_PHONE_AMY = "11111111";
@@ -68,6 +71,19 @@ public class CommandTestUtil {
 
     public static final EditCustomerCommand.EditCustomerDescriptor DESC_AMY;
     public static final EditCustomerCommand.EditCustomerDescriptor DESC_BOB;
+
+    // order
+
+    public static final String VALID_NAME_A = "Strawberry Shortcake";
+    public static final String VALID_NAME_B = "Banana Split";
+    public static final String VALID_QUANTITY_A = "5";
+    public static final String VALID_QUANTITY_B = "2";
+    public static final String VALID_STATUS_A = "Pending";
+    public static final String VALID_STATUS_B = "Paid";
+    public static final String VALID_ADDRESS_A = "10 Summer Drive, Singapore 3098812";
+    public static final String VALID_ADDRESS_B = "11 Fabordrive, Singapore 3001298";
+    public static final String VALID_CREATED_DATE_A = "2023/01/09";
+    public static final String VALID_CREATED_DATE_B = "2022/12/20";
 
     static {
         DESC_AMY = new EditCustomerDescriptorBuilder().withName(VALID_NAME_AMY)

--- a/src/test/java/seedu/loyaltylift/model/AddressBookTest.java
+++ b/src/test/java/seedu/loyaltylift/model/AddressBookTest.java
@@ -8,6 +8,7 @@ import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND
 import static seedu.loyaltylift.testutil.Assert.assertThrows;
 import static seedu.loyaltylift.testutil.TypicalCustomers.ALICE;
 import static seedu.loyaltylift.testutil.TypicalCustomers.getTypicalAddressBook;
+import static seedu.loyaltylift.testutil.TypicalOrders.ORDER_A;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -21,6 +22,7 @@ import javafx.collections.ObservableList;
 import seedu.loyaltylift.model.customer.Customer;
 import seedu.loyaltylift.model.customer.exceptions.DuplicateCustomerException;
 import seedu.loyaltylift.model.order.Order;
+import seedu.loyaltylift.model.order.exceptions.DuplicateOrderException;
 import seedu.loyaltylift.testutil.CustomerBuilder;
 
 public class AddressBookTest {
@@ -50,9 +52,17 @@ public class AddressBookTest {
         Customer editedAlice = new CustomerBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
                 .build();
         List<Customer> newCustomers = Arrays.asList(ALICE, editedAlice);
-        AddressBookStub newData = new AddressBookStub(newCustomers);
+        AddressBookStub newData = new AddressBookStub(newCustomers, Arrays.asList());
 
         assertThrows(DuplicateCustomerException.class, () -> addressBook.resetData(newData));
+    }
+
+    @Test
+    public void resetData_withDuplicateOrders_throwsDuplicateOrderException() {
+        List<Order> newOrders = Arrays.asList(ORDER_A, ORDER_A);
+        AddressBookStub newData = new AddressBookStub(Arrays.asList(), newOrders);
+
+        assertThrows(DuplicateOrderException.class, () -> addressBook.resetData(newData));
     }
 
     @Test
@@ -91,8 +101,9 @@ public class AddressBookTest {
         private final ObservableList<Customer> customers = FXCollections.observableArrayList();
         private final ObservableList<Order> orders = FXCollections.observableArrayList();
 
-        AddressBookStub(Collection<Customer> customers) {
+        AddressBookStub(Collection<Customer> customers, Collection<Order> orders) {
             this.customers.setAll(customers);
+            this.orders.setAll(orders);
         }
 
         @Override

--- a/src/test/java/seedu/loyaltylift/model/ModelManagerTest.java
+++ b/src/test/java/seedu/loyaltylift/model/ModelManagerTest.java
@@ -7,6 +7,7 @@ import static seedu.loyaltylift.model.Model.PREDICATE_SHOW_ALL_CUSTOMERS;
 import static seedu.loyaltylift.testutil.Assert.assertThrows;
 import static seedu.loyaltylift.testutil.TypicalCustomers.ALICE;
 import static seedu.loyaltylift.testutil.TypicalCustomers.BENSON;
+import static seedu.loyaltylift.testutil.TypicalOrders.ORDER_A;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -83,7 +84,7 @@ public class ModelManagerTest {
     }
 
     @Test
-    public void hasCustomern_customerInAddressBook_returnsTrue() {
+    public void hasCustomer_customerInAddressBook_returnsTrue() {
         modelManager.addCustomer(ALICE);
         assertTrue(modelManager.hasCustomer(ALICE));
     }
@@ -91,6 +92,27 @@ public class ModelManagerTest {
     @Test
     public void getFilteredCustomerList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredCustomerList().remove(0));
+    }
+
+    @Test
+    public void hasOrder_nullOrder_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.hasOrder(null));
+    }
+
+    @Test
+    public void hasOrder_orderNotInAddressBook_returnsFalse() {
+        assertFalse(modelManager.hasOrder(ORDER_A));
+    }
+
+    @Test
+    public void hasOrder_orderInAddressBook_returnsTrue() {
+        modelManager.addOrder(ORDER_A);
+        assertTrue(modelManager.hasOrder(ORDER_A));
+    }
+
+    @Test
+    public void getFilteredOrderList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredOrderList().remove(0));
     }
 
     @Test

--- a/src/test/java/seedu/loyaltylift/model/order/CreatedDateTest.java
+++ b/src/test/java/seedu/loyaltylift/model/order/CreatedDateTest.java
@@ -1,0 +1,40 @@
+package seedu.loyaltylift.model.order;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.loyaltylift.testutil.Assert.assertThrows;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+
+public class CreatedDateTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new CreatedDate(null));
+    }
+
+    @Test
+    public void constructor_invalidCreatedDate_throwsIllegalArgumentException() {
+        LocalDate invalidCreatedDate = LocalDate.now().plusDays(1);
+        assertThrows(IllegalArgumentException.class, () -> new CreatedDate(invalidCreatedDate));
+    }
+
+    @Test
+    public void isValidCreatedDate() {
+        // null date
+        assertThrows(NullPointerException.class, () -> CreatedDate.isValidCreatedDate(null));
+
+        LocalDate now = LocalDate.now();
+
+        // invalid date
+        assertFalse(CreatedDate.isValidCreatedDate(now.plusDays(1))); // tomorrow
+        assertFalse(CreatedDate.isValidCreatedDate(now.plusYears(1))); // one year later
+
+        // valid date
+        assertTrue(CreatedDate.isValidCreatedDate(now)); // today
+        assertTrue(CreatedDate.isValidCreatedDate(now.minusDays(1))); // one day ago
+        assertTrue(CreatedDate.isValidCreatedDate(now.minusYears(1))); // one year ago
+    }
+}

--- a/src/test/java/seedu/loyaltylift/model/order/OrderTest.java
+++ b/src/test/java/seedu/loyaltylift/model/order/OrderTest.java
@@ -1,0 +1,96 @@
+package seedu.loyaltylift.model.order;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_ADDRESS_B;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_CREATED_DATE_A;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_NAME_B;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_QUANTITY_B;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_STATUS_B;
+import static seedu.loyaltylift.testutil.TypicalOrders.ORDER_B;
+import static seedu.loyaltylift.testutil.TypicalOrders.ORDER_C;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.loyaltylift.testutil.OrderBuilder;
+
+public class OrderTest {
+
+    @Test
+    public void isSameOrder() {
+        // same values -> returns true
+        Order cCopy = new OrderBuilder(ORDER_C).build();
+        assertTrue(ORDER_C.equals(cCopy));
+
+        // same object -> returns true
+        assertTrue(ORDER_C.isSameOrder(ORDER_C));
+
+        // null -> returns false
+        assertFalse(ORDER_C.isSameOrder(null));
+
+        // different type -> returns false
+        assertFalse(ORDER_C.equals(5));
+
+        // different order -> returns false
+        assertFalse(ORDER_C.equals(ORDER_B));
+
+        // different name -> returns false
+        Order editedC = new OrderBuilder(ORDER_C).withName(VALID_NAME_B).build();
+        assertFalse(ORDER_C.equals(editedC));
+
+        // different quantity -> returns false
+        editedC = new OrderBuilder(ORDER_C).withQuantity(VALID_QUANTITY_B).build();
+        assertFalse(ORDER_C.equals(editedC));
+
+        // different status -> returns false
+        editedC = new OrderBuilder(ORDER_C).withStatus(VALID_STATUS_B).build();
+        assertFalse(ORDER_C.equals(editedC));
+
+        // different address -> returns false
+        editedC = new OrderBuilder(ORDER_C).withAddress(VALID_ADDRESS_B).build();
+        assertFalse(ORDER_C.equals(editedC));
+
+        // different created date -> returns false
+        editedC = new OrderBuilder(ORDER_C).withCreatedDate(VALID_CREATED_DATE_A).build();
+        assertFalse(ORDER_C.equals(editedC));
+    }
+
+    @Test
+    public void equals() {
+        // same values -> returns true
+        Order cCopy = new OrderBuilder(ORDER_C).build();
+        assertTrue(ORDER_C.equals(cCopy));
+
+        // same object -> returns true
+        assertTrue(ORDER_C.equals(ORDER_C));
+
+        // null -> returns false
+        assertFalse(ORDER_C.equals(null));
+
+        // different type -> returns false
+        assertFalse(ORDER_C.equals(5));
+
+        // different order -> returns false
+        assertFalse(ORDER_C.equals(ORDER_B));
+
+        // different name -> returns false
+        Order editedC = new OrderBuilder(ORDER_C).withName(VALID_NAME_B).build();
+        assertFalse(ORDER_C.equals(editedC));
+
+        // different quantity -> returns false
+        editedC = new OrderBuilder(ORDER_C).withQuantity(VALID_QUANTITY_B).build();
+        assertFalse(ORDER_C.equals(editedC));
+
+        // different status -> returns false
+        editedC = new OrderBuilder(ORDER_C).withStatus(VALID_STATUS_B).build();
+        assertFalse(ORDER_C.equals(editedC));
+
+        // different address -> returns false
+        editedC = new OrderBuilder(ORDER_C).withAddress(VALID_ADDRESS_B).build();
+        assertFalse(ORDER_C.equals(editedC));
+
+        // different created date -> returns false
+        editedC = new OrderBuilder(ORDER_C).withCreatedDate(VALID_CREATED_DATE_A).build();
+        assertFalse(ORDER_C.equals(editedC));
+    }
+}

--- a/src/test/java/seedu/loyaltylift/model/order/QuantityTest.java
+++ b/src/test/java/seedu/loyaltylift/model/order/QuantityTest.java
@@ -1,0 +1,35 @@
+package seedu.loyaltylift.model.order;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.loyaltylift.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class QuantityTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Quantity(null));
+    }
+
+    @Test
+    public void constructor_invalidQuantity_throwsIllegalArgumentException() {
+        int invalidQuantity = 0;
+        assertThrows(IllegalArgumentException.class, () -> new Quantity(invalidQuantity));
+    }
+
+    @Test
+    public void isValidQuantity() {
+        // null quantity
+        assertThrows(NullPointerException.class, () -> Quantity.isValidQuantity(null));
+
+        // invalid quantity
+        assertFalse(Quantity.isValidQuantity(0)); // zero
+        assertFalse(Quantity.isValidQuantity(-1)); // negative number
+
+        // valid quantity
+        assertTrue(Quantity.isValidQuantity(1)); // positive number
+        assertTrue(Quantity.isValidQuantity(Integer.MAX_VALUE)); // max positive number
+    }
+}

--- a/src/test/java/seedu/loyaltylift/model/order/StatusTest.java
+++ b/src/test/java/seedu/loyaltylift/model/order/StatusTest.java
@@ -1,0 +1,43 @@
+package seedu.loyaltylift.model.order;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.loyaltylift.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class StatusTest {
+
+    @Test
+    public void fromString_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> Status.fromString(null));
+    }
+
+    @Test
+    public void fromString_invalidString_throwsIllegalArgumentException() {
+        String invalidString = "";
+        assertThrows(IllegalArgumentException.class, () -> Status.fromString(invalidString));
+    }
+
+    @Test
+    public void fromString_validString() {
+        assertEquals(Status.fromString("PENDING"), Status.PENDING);
+        assertEquals(Status.fromString("Pending"), Status.PENDING);
+        assertEquals(Status.fromString("pending"), Status.PENDING);
+
+        assertEquals(Status.fromString("PAID"), Status.PAID);
+        assertEquals(Status.fromString("Paid"), Status.PAID);
+        assertEquals(Status.fromString("paid"), Status.PAID);
+
+        assertEquals(Status.fromString("SHIPPED"), Status.SHIPPED);
+        assertEquals(Status.fromString("Shipped"), Status.SHIPPED);
+        assertEquals(Status.fromString("shipped"), Status.SHIPPED);
+
+        assertEquals(Status.fromString("COMPLETED"), Status.COMPLETED);
+        assertEquals(Status.fromString("Completed"), Status.COMPLETED);
+        assertEquals(Status.fromString("completed"), Status.COMPLETED);
+
+        assertEquals(Status.fromString("CANCELLED"), Status.CANCELLED);
+        assertEquals(Status.fromString("Cancelled"), Status.CANCELLED);
+        assertEquals(Status.fromString("cancelled"), Status.CANCELLED);
+    }
+}

--- a/src/test/java/seedu/loyaltylift/model/order/UniqueOrderListTest.java
+++ b/src/test/java/seedu/loyaltylift/model/order/UniqueOrderListTest.java
@@ -1,0 +1,167 @@
+package seedu.loyaltylift.model.order;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.loyaltylift.testutil.Assert.assertThrows;
+import static seedu.loyaltylift.testutil.TypicalOrders.ORDER_B;
+import static seedu.loyaltylift.testutil.TypicalOrders.ORDER_C;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.loyaltylift.model.order.exceptions.DuplicateOrderException;
+import seedu.loyaltylift.model.order.exceptions.OrderNotFoundException;
+import seedu.loyaltylift.testutil.OrderBuilder;
+
+public class UniqueOrderListTest {
+
+    private final UniqueOrderList uniqueOrderList = new UniqueOrderList();
+
+    @Test
+    public void contains_nullOrder_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueOrderList.contains(null));
+    }
+
+    @Test
+    public void contains_orderNotInList_returnsFalse() {
+        assertFalse(uniqueOrderList.contains(ORDER_C));
+    }
+
+    @Test
+    public void contains_orderInList_returnsTrue() {
+        uniqueOrderList.add(ORDER_C);
+        assertTrue(uniqueOrderList.contains(ORDER_C));
+    }
+
+    @Test
+    public void contains_orderWithSameIdentityFieldsInList_returnsTrue() {
+        uniqueOrderList.add(ORDER_C);
+        Order cCopy = new OrderBuilder(ORDER_C).build();
+        assertTrue(uniqueOrderList.contains(cCopy));
+    }
+
+    @Test
+    public void add_nullOrder_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueOrderList.add(null));
+    }
+
+    @Test
+    public void add_duplicateOrder_throwsDuplicateOrderException() {
+        uniqueOrderList.add(ORDER_C);
+        assertThrows(DuplicateOrderException.class, () -> uniqueOrderList.add(ORDER_C));
+    }
+
+    @Test
+    public void setOrder_nullTargetOrder_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueOrderList.setOrder(null, ORDER_C));
+    }
+
+    @Test
+    public void setOrder_nullEditedOrder_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueOrderList.setOrder(ORDER_C, null));
+    }
+
+    @Test
+    public void setOrder_targetOrderNotInList_throwsOrderNotFoundException() {
+        assertThrows(OrderNotFoundException.class, () -> uniqueOrderList.setOrder(ORDER_C, ORDER_C));
+    }
+
+    @Test
+    public void setOrder_editedOrderIsSameOrder_success() {
+        uniqueOrderList.add(ORDER_C);
+        uniqueOrderList.setOrder(ORDER_C, ORDER_C);
+        UniqueOrderList expectedUniqueOrderList = new UniqueOrderList();
+        expectedUniqueOrderList.add(ORDER_C);
+        assertEquals(expectedUniqueOrderList, uniqueOrderList);
+    }
+
+    @Test
+    public void setCustomer_editedOrderHasSameIdentity_success() {
+        uniqueOrderList.add(ORDER_C);
+        Order cCopy = new OrderBuilder(ORDER_C).build();
+        uniqueOrderList.setOrder(ORDER_C, cCopy);
+        UniqueOrderList expectedUniqueOrderList = new UniqueOrderList();
+        expectedUniqueOrderList.add(cCopy);
+        assertEquals(expectedUniqueOrderList, uniqueOrderList);
+    }
+
+    @Test
+    public void setOrder_editedOrderHasDifferentIdentity_success() {
+        uniqueOrderList.add(ORDER_C);
+        uniqueOrderList.setOrder(ORDER_C, ORDER_B);
+        UniqueOrderList expectedUniqueOrderList = new UniqueOrderList();
+        expectedUniqueOrderList.add(ORDER_B);
+        assertEquals(expectedUniqueOrderList, uniqueOrderList);
+    }
+
+    @Test
+    public void setOrder_editedOrderHasNonUniqueIdentity_throwsDuplicateOrderException() {
+        uniqueOrderList.add(ORDER_C);
+        uniqueOrderList.add(ORDER_B);
+        assertThrows(DuplicateOrderException.class, () -> uniqueOrderList.setOrder(ORDER_C, ORDER_B));
+    }
+
+    @Test
+    public void remove_nullOrder_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueOrderList.remove(null));
+    }
+
+    @Test
+    public void remove_orderDoesNotExist_throwsOrderNotFoundException() {
+        assertThrows(OrderNotFoundException.class, () -> uniqueOrderList.remove(ORDER_C));
+    }
+
+    @Test
+    public void remove_existingOrder_removesOrder() {
+        uniqueOrderList.add(ORDER_C);
+        uniqueOrderList.remove(ORDER_C);
+        UniqueOrderList expectedUniqueOrderList = new UniqueOrderList();
+        assertEquals(expectedUniqueOrderList, uniqueOrderList);
+    }
+
+    @Test
+    public void setOrders_nullUniqueOrderList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueOrderList.setOrders((UniqueOrderList) null));
+    }
+
+    @Test
+    public void setOrders_uniqueOrderList_replacesOwnListWithProvidedUniqueOrderList() {
+        uniqueOrderList.add(ORDER_C);
+        UniqueOrderList expectedUniqueOrderList = new UniqueOrderList();
+        expectedUniqueOrderList.add(ORDER_B);
+        uniqueOrderList.setOrders(expectedUniqueOrderList);
+        assertEquals(expectedUniqueOrderList, uniqueOrderList);
+    }
+
+    @Test
+    public void setOrders_nullList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueOrderList.setOrders((List<Order>) null));
+    }
+
+    @Test
+    public void setOrders_list_replacesOwnListWithProvidedList() {
+        uniqueOrderList.add(ORDER_C);
+        List<Order> orderList = Collections.singletonList(ORDER_B);
+        uniqueOrderList.setOrders(orderList);
+        UniqueOrderList expectedUniqueOrderList = new UniqueOrderList();
+        expectedUniqueOrderList.add(ORDER_B);
+        assertEquals(expectedUniqueOrderList, uniqueOrderList);
+    }
+
+    @Test
+    public void setOrders_listWithDuplicateOrders_throwsDuplicateOrderException() {
+        List<Order> listWithDuplicateOrders = Arrays.asList(ORDER_C, ORDER_C);
+        assertThrows(
+                DuplicateOrderException.class, () -> uniqueOrderList.setOrders(listWithDuplicateOrders));
+    }
+
+    @Test
+    public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, ()
+            -> uniqueOrderList.asUnmodifiableObservableList().remove(0));
+    }
+}

--- a/src/test/java/seedu/loyaltylift/testutil/AddressBookBuilder.java
+++ b/src/test/java/seedu/loyaltylift/testutil/AddressBookBuilder.java
@@ -2,6 +2,7 @@ package seedu.loyaltylift.testutil;
 
 import seedu.loyaltylift.model.AddressBook;
 import seedu.loyaltylift.model.customer.Customer;
+import seedu.loyaltylift.model.order.Order;
 
 /**
  * A utility class to help with building Addressbook objects.
@@ -25,6 +26,14 @@ public class AddressBookBuilder {
      */
     public AddressBookBuilder withCustomer(Customer customer) {
         addressBook.addCustomer(customer);
+        return this;
+    }
+
+    /**
+     * Adds a new {@code Order} to the {@code AddressBook} that we are building.
+     */
+    public AddressBookBuilder withOrder(Order order) {
+        addressBook.addOrder(order);
         return this;
     }
 

--- a/src/test/java/seedu/loyaltylift/testutil/OrderBuilder.java
+++ b/src/test/java/seedu/loyaltylift/testutil/OrderBuilder.java
@@ -1,0 +1,96 @@
+package seedu.loyaltylift.testutil;
+
+import java.time.LocalDate;
+
+import seedu.loyaltylift.model.attribute.Address;
+import seedu.loyaltylift.model.attribute.Name;
+import seedu.loyaltylift.model.order.CreatedDate;
+import seedu.loyaltylift.model.order.Order;
+import seedu.loyaltylift.model.order.Quantity;
+import seedu.loyaltylift.model.order.Status;
+import seedu.loyaltylift.model.util.SampleDataUtil;
+
+/**
+ * A utility class to help with building Order objects.
+ */
+public class OrderBuilder {
+
+    public static final String DEFAULT_NAME = "Banana Split";
+    public static final int DEFAULT_QUANTITY = 2;
+    public static final Status DEFAULT_STATUS = Status.PAID;
+    public static final String DEFAULT_ADDRESS = "11 Fabordrive, Singapore 3001298";
+    public static final LocalDate DEFAULT_DATE = LocalDate.of(2022, 12, 20);
+
+    private Name name;
+    private Quantity quantity;
+    private Status status;
+    private Address address;
+    private CreatedDate createdDate;
+
+    /**
+     * Creates a {@code OrderBuilder} with the default details.
+     */
+    public OrderBuilder() {
+        name = new Name(DEFAULT_NAME);
+        quantity = new Quantity(DEFAULT_QUANTITY);
+        status = DEFAULT_STATUS;
+        address = new Address(DEFAULT_ADDRESS);
+        createdDate = new CreatedDate(DEFAULT_DATE);
+    }
+
+    /**
+     * Initializes the OrderBuilder with the data of {@code orderToCopy}.
+     */
+    public OrderBuilder(Order orderToCopy) {
+        name = orderToCopy.getName();
+        quantity = orderToCopy.getQuantity();
+        status = orderToCopy.getStatus();
+        address = orderToCopy.getAddress();
+        createdDate = orderToCopy.getCreatedDate();
+    }
+
+    /**
+     * Sets the {@code Name} of the {@code Order} that we are building.
+     */
+    public OrderBuilder withName(String name) {
+        this.name = new Name(name);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Quantity} of the {@code Order} that we are building.
+     */
+    public OrderBuilder withQuantity(String quantity) {
+        this.quantity = SampleDataUtil.getQuantity(quantity);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Status} of the {@code Order} that we are building.
+     */
+    public OrderBuilder withStatus(String status) {
+        this.status = SampleDataUtil.getStatus(status);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Address} of the {@code Order} that we are building.
+     */
+    public OrderBuilder withAddress(String address) {
+        this.address = new Address(address);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Email} of the {@code Order} that we are building.
+     */
+    public OrderBuilder withCreatedDate(String createdDate) {
+        this.createdDate = SampleDataUtil.getCreatedDate(createdDate);
+        return this;
+    }
+
+    public Order build() {
+        return new Order(name, quantity, status, address, createdDate);
+    }
+
+}

--- a/src/test/java/seedu/loyaltylift/testutil/TypicalOrders.java
+++ b/src/test/java/seedu/loyaltylift/testutil/TypicalOrders.java
@@ -1,0 +1,59 @@
+package seedu.loyaltylift.testutil;
+
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_ADDRESS_A;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_ADDRESS_B;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_CREATED_DATE_A;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_CREATED_DATE_B;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_NAME_A;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_NAME_B;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_QUANTITY_A;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_QUANTITY_B;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_STATUS_A;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_STATUS_B;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import seedu.loyaltylift.model.AddressBook;
+import seedu.loyaltylift.model.order.Order;
+
+/**
+ * A utility class containing a list of {@code Order} objects to be used in tests.
+ */
+public class TypicalOrders {
+    // Manually added - Order's details found in {@code CommandTestUtil}
+    public static final Order ORDER_A = new OrderBuilder().withName(VALID_NAME_A).withQuantity(VALID_QUANTITY_A)
+            .withStatus(VALID_STATUS_A).withAddress(VALID_ADDRESS_A).withCreatedDate(VALID_CREATED_DATE_A).build();
+    public static final Order ORDER_B = new OrderBuilder().withName(VALID_NAME_B).withQuantity(VALID_QUANTITY_B)
+            .withStatus(VALID_STATUS_B).withAddress(VALID_ADDRESS_B).withCreatedDate(VALID_CREATED_DATE_B).build();
+
+    // Manually added
+    public static final Order ORDER_C = new OrderBuilder().withName("Melon Cookie")
+            .withAddress("9 Bishan Rd, Singapore 310909").withStatus("Shipped")
+            .withQuantity("50").withCreatedDate("2022/12/20").build();
+    public static final Order ORDER_D = new OrderBuilder().withName("Strawberry Shortcake")
+            .withAddress("9 Bishan Rd, Singapore 310909")
+            .withStatus("Completed").withQuantity("3")
+            .withCreatedDate("2022/12/12").build();
+
+
+    public static final String KEYWORD_MATCHING_SHORTCAKE = "Shortcake"; // A keyword that matches Shortcake
+
+    private TypicalOrders() {} // prevents instantiation
+
+    /**
+     * Returns an {@code AddressBook} with all the typical orders.
+     */
+    public static AddressBook getTypicalAddressBook() {
+        AddressBook ab = new AddressBook();
+        for (Order order : getTypicalOrders()) {
+            ab.addOrder(order);
+        }
+        return ab;
+    }
+
+    public static List<Order> getTypicalOrders() {
+        return new ArrayList<>(Arrays.asList(ORDER_A, ORDER_B, ORDER_C, ORDER_D));
+    }
+}


### PR DESCRIPTION
Add unit tests for `Order` - very similar to the ones for `Customer`

**Note about `Order::isSameOrder`**
* Each `Customer` is uniquely identified by their name, as defined by `Customer::isSameCustomer`
* `Order` also has an `Order::isSameOrder` but I've just set that to execute `Order::equals` to make an order uniquely identified by all its properties
* So, the tests for `Order::isSameOrder` are pretty much the same as `Order::equals`

Depends on #36
Closes #23