### PR TITLE
feat: add command for adding and deducting points from customers, also added cumulative points

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -122,6 +122,8 @@ Format: `setpoints INDEX pt/POINTS`
 * The points refers to the reward points of the customer
 * The points **must be a positive integer** 1, 2, 3, ​​…
 * The points can only range from 0 to 999999
+* Setting points will also set cumulative points to the same amount, if you wish to keep the current cumulative points,
+use the `addpoints` command instead.
 
 Examples:
 * `listc` followed by `setpoints 2 pt/100` sets the 2nd customer points as 100.
@@ -131,7 +133,7 @@ Examples:
 
 Edits a customer's reward points by adding or removing from it.
 
-Format: `addpoints INDEX +/-POINTS`
+Format: `addpoints INDEX pt/[+/-]POINTS`
 
 * Add or subtract the points of the customer at the specified `INDEX` to `POINTS`.
 * If the points subtracted is greater than what the user has, the command will not be executed
@@ -141,10 +143,12 @@ Format: `addpoints INDEX +/-POINTS`
 * The +/- refers to whether you wish to add or subtract from the reward points of the customer, + to add, - to subtract
 * The points refers to how much you wish to add or subtract the reward points of the customer
 * The points **must be a positive integer** 1, 2, 3, ​​…
+* Addition will also result in an addition of cumulative points, subtraction will not change cumulative points.
 
 Examples:
-* `listc` followed by `addpoints 2 100` adds 100 reward points to the 2nd customer.
-* `findc Betsy` followed by `addpoints 1 300` adds 300 reward poitns to the 1st customer in the results of the `findc` command.
+* `listc` followed by `addpoints 2 pt/100` adds 100 reward points to the 2nd customer.
+* `findc Betsy` followed by `addpoints 1 pt/-300` deducts 300 reward points from 
+the 1st customer in the results of the `findc` command.
 
 ### Setting tiers for your reward system : `settier`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -147,7 +147,7 @@ Format: `addpoints INDEX pt/[+/-]POINTS`
 
 Examples:
 * `listc` followed by `addpoints 2 pt/100` adds 100 reward points to the 2nd customer.
-* `findc Betsy` followed by `addpoints 1 pt/-300` deducts 300 reward points from 
+* `findc Betsy` followed by `addpoints 1 pt/-300` deducts 300 reward points from
 the 1st customer in the results of the `findc` command.
 
 ### Setting tiers for your reward system : `settier`

--- a/src/main/java/seedu/loyaltylift/logic/commands/AddPointsCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/AddPointsCommand.java
@@ -1,0 +1,129 @@
+package seedu.loyaltylift.logic.commands;
+
+import static seedu.loyaltylift.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_POINTS;
+import static seedu.loyaltylift.model.Model.PREDICATE_SHOW_ALL_CUSTOMERS;
+
+import java.util.List;
+import java.util.Set;
+
+import seedu.loyaltylift.commons.core.Messages;
+import seedu.loyaltylift.commons.core.index.Index;
+import seedu.loyaltylift.commons.exceptions.IllegalValueException;
+import seedu.loyaltylift.logic.commands.exceptions.CommandException;
+
+import seedu.loyaltylift.model.Model;
+import seedu.loyaltylift.model.attribute.Address;
+import seedu.loyaltylift.model.attribute.Name;
+import seedu.loyaltylift.model.customer.Customer;
+import seedu.loyaltylift.model.customer.CustomerType;
+import seedu.loyaltylift.model.customer.Email;
+import seedu.loyaltylift.model.customer.Phone;
+import seedu.loyaltylift.model.customer.Points;
+import seedu.loyaltylift.model.tag.Tag;
+
+/**
+ * Adds the reward points of a customer
+ * Points added could be negative
+ */
+public class AddPointsCommand extends Command {
+
+    public static final String COMMAND_WORD = "addpoints";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": edits points of the customer identified by the index number used in the displayed customer list. \n"
+            + "Parameters: "
+            + "INDEX (must be a positive integer) "
+            + PREFIX_POINTS + "[POINTS]\n"
+            + "Example: " + COMMAND_WORD
+            + " 1 "
+            + "pt/-100";
+
+    public static final String MESSAGE_ARGUMENTS = "Index: %1$s, Points: %2$s";
+
+    public static final String MESSAGE_SET_POINTS_SUCCESS = "Current points for Customer: %1$s";
+    public static final String MESSAGE_INVALID_POINTS = "This customer will have invalid points";
+
+    private final Index index;
+    private final Points.AddPoints addPoints;
+
+    /**
+     * @param index of the customer in the filtered person list to set points
+     * @param addPoints of the customer to be set
+     */
+    public AddPointsCommand(Index index, Points.AddPoints addPoints) {
+        requireAllNonNull(index, addPoints);
+
+        this.index = index;
+        this.addPoints = addPoints;
+    }
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        List<Customer> lastShownList = model.getFilteredCustomerList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_CUSTOMER_DISPLAYED_INDEX);
+        }
+
+        Customer customerToEdit = lastShownList.get(index.getZeroBased());
+        Customer editedCustomerWithPoints = createEditedCustomer(customerToEdit);
+
+        model.setCustomer(customerToEdit, editedCustomerWithPoints);
+        model.updateFilteredCustomerList(PREDICATE_SHOW_ALL_CUSTOMERS);
+
+        return new CommandResult(generateSuccessMessage(editedCustomerWithPoints));
+    }
+
+    /**
+     * Creates and returns a {@code Customer} with the details of {@code customerToEdit}
+     */
+    private Customer createEditedCustomer(Customer customerToEdit) throws CommandException {
+        assert customerToEdit != null;
+        CustomerType customerType = customerToEdit.getCustomerType();
+        Name name = customerToEdit.getName();
+        Phone phone = customerToEdit.getPhone();
+        Email email = customerToEdit.getEmail();
+        Address address = customerToEdit.getAddress();
+        Set<Tag> tags = customerToEdit.getTags();
+        Points points = customerToEdit.getPoints();
+
+        Points newPoints;
+        try {
+            newPoints = points.editPoints(this.addPoints);
+        } catch (IllegalValueException e) {
+            throw new CommandException(MESSAGE_INVALID_POINTS);
+        }
+
+        return new Customer(customerType, name, phone, email, address, tags, newPoints);
+    }
+
+
+
+    /**
+     * Generates a command execution success message based on whether
+     * the points are added
+     */
+    private String generateSuccessMessage(Customer editedCustomer) {
+        String message = MESSAGE_SET_POINTS_SUCCESS;
+        return String.format(message, editedCustomer);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddPointsCommand)) {
+            return false;
+        }
+
+        // state check
+        AddPointsCommand e = (AddPointsCommand) other;
+        return index.equals(e.index)
+                && addPoints.equals(e.addPoints);
+    }
+}
+

--- a/src/main/java/seedu/loyaltylift/logic/commands/AddPointsCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/AddPointsCommand.java
@@ -11,7 +11,6 @@ import seedu.loyaltylift.commons.core.Messages;
 import seedu.loyaltylift.commons.core.index.Index;
 import seedu.loyaltylift.commons.exceptions.IllegalValueException;
 import seedu.loyaltylift.logic.commands.exceptions.CommandException;
-
 import seedu.loyaltylift.model.Model;
 import seedu.loyaltylift.model.attribute.Address;
 import seedu.loyaltylift.model.attribute.Name;

--- a/src/main/java/seedu/loyaltylift/logic/commands/AddPointsCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/AddPointsCommand.java
@@ -36,7 +36,8 @@ public class AddPointsCommand extends Command {
             + PREFIX_POINTS + "[POINTS]\n"
             + "Example: " + COMMAND_WORD
             + " 1 "
-            + "pt/-100";
+            + PREFIX_POINTS
+            + "-100";
 
     public static final String MESSAGE_ARGUMENTS = "Index: %1$s, Points: %2$s";
 
@@ -44,13 +45,13 @@ public class AddPointsCommand extends Command {
     public static final String MESSAGE_INVALID_POINTS = "This customer will have invalid points";
 
     private final Index index;
-    private final Points.AddPoints addPoints;
+    private final Integer addPoints;
 
     /**
      * @param index of the customer in the filtered person list to set points
-     * @param addPoints of the customer to be set
+     * @param addPoints points to be added or subtracted
      */
-    public AddPointsCommand(Index index, Points.AddPoints addPoints) {
+    public AddPointsCommand(Index index, Integer addPoints) {
         requireAllNonNull(index, addPoints);
 
         this.index = index;

--- a/src/main/java/seedu/loyaltylift/logic/commands/SetPointsCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/SetPointsCommand.java
@@ -73,7 +73,6 @@ public class SetPointsCommand extends Command {
 
     /**
      * Creates and returns a {@code Customer} with the details of {@code customerToEdit}
-     * edited with {@code editCustomerDescriptor}.
      */
     private Customer createEditedCustomer(Customer customerToEdit) {
         assert customerToEdit != null;
@@ -90,7 +89,6 @@ public class SetPointsCommand extends Command {
     /**
      * Generates a command execution success message based on whether
      * the points are set
-     * {@code personToEdit}.
      */
     private String generateSuccessMessage(Customer editedCustomer) {
         String message = MESSAGE_SET_POINTS_SUCCESS;

--- a/src/main/java/seedu/loyaltylift/logic/commands/SetPointsCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/SetPointsCommand.java
@@ -34,7 +34,8 @@ public class SetPointsCommand extends Command {
             + PREFIX_POINTS + "[POINTS]\n"
             + "Example: " + COMMAND_WORD
             + " 1 "
-            + "pt/100";
+            + PREFIX_POINTS
+            + "100";
 
     public static final String MESSAGE_ARGUMENTS = "Index: %1$s, Points: %2$s";
 

--- a/src/main/java/seedu/loyaltylift/logic/parser/AddPointsCommandParser.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/AddPointsCommandParser.java
@@ -1,0 +1,46 @@
+package seedu.loyaltylift.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.loyaltylift.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_POINTS;
+
+import java.util.stream.Stream;
+
+import seedu.loyaltylift.commons.core.index.Index;
+import seedu.loyaltylift.logic.commands.AddPointsCommand;
+import seedu.loyaltylift.logic.parser.exceptions.ParseException;
+import seedu.loyaltylift.model.customer.Points;
+
+/**
+ * Parses input arguments and creates a new AddPointsCommand object
+ */
+public class AddPointsCommandParser implements Parser<AddPointsCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddPointsCommand
+     * and returns an AddPointsCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddPointsCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_POINTS);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_POINTS)
+                || argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddPointsCommand.MESSAGE_USAGE));
+        }
+        Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        Points.AddPoints addPoints = ParserUtil.parseAddPoints((argMultimap.getValue(PREFIX_POINTS).get()));
+
+        return new AddPointsCommand(index, addPoints);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}
+

--- a/src/main/java/seedu/loyaltylift/logic/parser/AddPointsCommandParser.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/AddPointsCommandParser.java
@@ -9,7 +9,6 @@ import java.util.stream.Stream;
 import seedu.loyaltylift.commons.core.index.Index;
 import seedu.loyaltylift.logic.commands.AddPointsCommand;
 import seedu.loyaltylift.logic.parser.exceptions.ParseException;
-import seedu.loyaltylift.model.customer.Points;
 
 /**
  * Parses input arguments and creates a new AddPointsCommand object
@@ -30,7 +29,7 @@ public class AddPointsCommandParser implements Parser<AddPointsCommand> {
                     AddPointsCommand.MESSAGE_USAGE));
         }
         Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        Points.AddPoints addPoints = ParserUtil.parseAddPoints((argMultimap.getValue(PREFIX_POINTS).get()));
+        Integer addPoints = ParserUtil.parseAddPoints((argMultimap.getValue(PREFIX_POINTS).get()));
 
         return new AddPointsCommand(index, addPoints);
     }

--- a/src/main/java/seedu/loyaltylift/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/AddressBookParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.loyaltylift.logic.commands.AddCustomerCommand;
+import seedu.loyaltylift.logic.commands.AddPointsCommand;
 import seedu.loyaltylift.logic.commands.ClearCommand;
 import seedu.loyaltylift.logic.commands.Command;
 import seedu.loyaltylift.logic.commands.DeleteCustomerCommand;
@@ -75,6 +76,9 @@ public class AddressBookParser {
 
         case SetPointsCommand.COMMAND_WORD:
             return new SetPointsCommandParser().parse(arguments);
+
+        case AddPointsCommand.COMMAND_WORD:
+            return new AddPointsCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/loyaltylift/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/CliSyntax.java
@@ -12,8 +12,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_CUSTOMER_TYPE = new Prefix("ct/");
-
     public static final Prefix PREFIX_POINTS = new Prefix("pt/");
-
 
 }

--- a/src/main/java/seedu/loyaltylift/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/ParserUtil.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import seedu.loyaltylift.commons.core.index.Index;
 import seedu.loyaltylift.commons.util.StringUtil;
+import seedu.loyaltylift.logic.commands.AddPointsCommand;
 import seedu.loyaltylift.logic.parser.exceptions.ParseException;
 import seedu.loyaltylift.model.attribute.Address;
 import seedu.loyaltylift.model.attribute.Name;
@@ -139,9 +140,9 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String points} into an {@code Points}.
+     * Parses a {@code String points} into a {@code Points}.
      *
-     * @throws ParseException if the given {@code address} is invalid.
+     * @throws ParseException if the given {@code points} is invalid.
      */
     public static Points parsePoints(String points) throws ParseException {
         requireNonNull(points);
@@ -158,5 +159,35 @@ public class ParserUtil {
             throw new ParseException(Points.MESSAGE_CONSTRAINTS);
         }
         return new Points(integerTrimmedPoints);
+    }
+
+    /**
+     * Parses a {@code String points} into a {@code AddPoints}.
+     *
+     * @throws ParseException if the given {@code points} is invalid.
+     */
+    public static Points.AddPoints parseAddPoints(String points) throws ParseException {
+        requireNonNull(points);
+        String trimmedPoints = points.trim();
+        Integer integerTrimmedPoints;
+        Points.AddPoints.Modifier modifier;
+        try {
+            integerTrimmedPoints = Integer.valueOf(trimmedPoints);
+        } catch (NumberFormatException e) {
+            // integerTrimmedPoints is a string that cannot be parsed
+            throw new ParseException(Points.AddPoints.MESSAGE_CONSTRAINTS);
+        }
+        if (integerTrimmedPoints < 0) {
+            integerTrimmedPoints = Math.abs(integerTrimmedPoints);
+            modifier = Points.AddPoints.Modifier.MINUS;
+        } else {
+            modifier = Points.AddPoints.Modifier.PLUS;
+        }
+
+        if (!Points.isValidPoints(integerTrimmedPoints)) {
+            // integerTrimmedPoints is an integer that is not within the range of 0 to 999999
+            throw new ParseException(Points.AddPoints.MESSAGE_CONSTRAINTS);
+        }
+        return new Points.AddPoints(integerTrimmedPoints, modifier);
     }
 }

--- a/src/main/java/seedu/loyaltylift/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/ParserUtil.java
@@ -8,7 +8,6 @@ import java.util.Set;
 
 import seedu.loyaltylift.commons.core.index.Index;
 import seedu.loyaltylift.commons.util.StringUtil;
-import seedu.loyaltylift.logic.commands.AddPointsCommand;
 import seedu.loyaltylift.logic.parser.exceptions.ParseException;
 import seedu.loyaltylift.model.attribute.Address;
 import seedu.loyaltylift.model.attribute.Name;

--- a/src/main/java/seedu/loyaltylift/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/ParserUtil.java
@@ -158,7 +158,7 @@ public class ParserUtil {
             // integerTrimmedPoints is an integer that is not within the range of 0 to 999999
             throw new ParseException(Points.MESSAGE_CONSTRAINTS);
         }
-        return new Points(integerTrimmedPoints);
+        return new Points(integerTrimmedPoints, integerTrimmedPoints);
     }
 
     /**

--- a/src/main/java/seedu/loyaltylift/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/ParserUtil.java
@@ -161,32 +161,25 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String points} into a {@code AddPoints}.
+     * Parses a {@code String points} into a {@code Integer}.
      *
      * @throws ParseException if the given {@code points} is invalid.
      */
-    public static Points.AddPoints parseAddPoints(String points) throws ParseException {
+    public static Integer parseAddPoints(String points) throws ParseException {
         requireNonNull(points);
         String trimmedPoints = points.trim();
         Integer integerTrimmedPoints;
-        Points.AddPoints.Modifier modifier;
         try {
             integerTrimmedPoints = Integer.valueOf(trimmedPoints);
         } catch (NumberFormatException e) {
             // integerTrimmedPoints is a string that cannot be parsed
-            throw new ParseException(Points.AddPoints.MESSAGE_CONSTRAINTS);
-        }
-        if (integerTrimmedPoints < 0) {
-            integerTrimmedPoints = Math.abs(integerTrimmedPoints);
-            modifier = Points.AddPoints.Modifier.MINUS;
-        } else {
-            modifier = Points.AddPoints.Modifier.PLUS;
+            throw new ParseException(Points.MESSAGE_CONSTRAINTS);
         }
 
-        if (!Points.isValidPoints(integerTrimmedPoints)) {
+        if (!Points.isValidAddition(integerTrimmedPoints)) {
             // integerTrimmedPoints is an integer that is not within the range of 0 to 999999
-            throw new ParseException(Points.AddPoints.MESSAGE_CONSTRAINTS);
+            throw new ParseException(Points.MESSAGE_CONSTRAINTS_ADDITION);
         }
-        return new Points.AddPoints(integerTrimmedPoints, modifier);
+        return integerTrimmedPoints;
     }
 }

--- a/src/main/java/seedu/loyaltylift/model/customer/Customer.java
+++ b/src/main/java/seedu/loyaltylift/model/customer/Customer.java
@@ -39,7 +39,7 @@ public class Customer {
         this.email = email;
         this.address = address;
         this.tags.addAll(tags);
-        this.points = new Points(0);
+        this.points = new Points(0, 0);
     }
 
     /**
@@ -122,7 +122,8 @@ public class Customer {
                 && otherCustomer.getEmail().equals(getEmail())
                 && otherCustomer.getAddress().equals(getAddress())
                 && otherCustomer.getTags().equals(getTags())
-                && otherCustomer.getCustomerType().equals(getCustomerType());
+                && otherCustomer.getCustomerType().equals(getCustomerType())
+                && otherCustomer.getPoints().equals(getPoints());
     }
 
     @Override

--- a/src/main/java/seedu/loyaltylift/model/customer/Points.java
+++ b/src/main/java/seedu/loyaltylift/model/customer/Points.java
@@ -1,5 +1,8 @@
 package seedu.loyaltylift.model.customer;
 
+import seedu.loyaltylift.commons.exceptions.IllegalValueException;
+import seedu.loyaltylift.logic.commands.AddPointsCommand;
+
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -27,6 +30,31 @@ public class Points {
         value = points;
     }
 
+    public Points editPoints(Points.AddPoints p) throws IllegalValueException {
+        Points newPoints = p.modifier.isPositive()
+                ? addPoints(p)
+                : subtractPoints(p);
+        return newPoints;
+    }
+
+    private Points addPoints(Points.AddPoints p) throws IllegalValueException {
+        Integer newPoints = this.value + p.value;
+        if (isValidPoints(newPoints)) {
+            return new Points(newPoints);
+        } else {
+            throw new IllegalValueException(Points.MESSAGE_CONSTRAINTS);
+        }
+    }
+
+    private Points subtractPoints(Points.AddPoints p) throws IllegalValueException {
+        Integer newPoints = this.value - p.value;
+        if (isValidPoints(newPoints)) {
+            return new Points(newPoints);
+        } else {
+            throw new IllegalValueException(Points.MESSAGE_CONSTRAINTS);
+        }
+    }
+
     /**
      * Returns true if a given point is valid.
      */
@@ -50,5 +78,57 @@ public class Points {
     @Override
     public int hashCode() {
         return value.hashCode();
+    }
+
+    public static class AddPoints {
+        public enum Modifier {
+            PLUS("+"),
+            MINUS("-");
+
+            public static final String MESSAGE_CONSTRAINTS = "Modifier must '+' or '-'";
+
+            private String value;
+            private Modifier(String value) {
+                this.value = value;
+            }
+
+            public boolean isPositive() {
+                return (this.toString().compareTo("+") == 0);
+            }
+
+            public String toString() {
+                return this.value;
+            }
+        }
+
+        public final Integer value;
+        public final Modifier modifier;
+        public static final String MESSAGE_CONSTRAINTS = "In the addpoints command, points must be an integer.\n"
+                + "Points can only range from 0 to 999 999.\n"
+                + "A modifier, '+' or '-' can be added in front of points to add or subtract points respectively.\n"
+                + "If no such modifier exists, addpoints command will default to an addition.";
+
+        public AddPoints(Integer value, Modifier modifier) {
+            this.value = value;
+            this.modifier = modifier;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof Points.AddPoints)) {
+                return false;
+            }
+
+            // state check
+            Points.AddPoints e = (Points.AddPoints) other;
+            return value.equals(e.value)
+                    && modifier.equals(e.modifier);
+        }
     }
 }

--- a/src/main/java/seedu/loyaltylift/model/customer/Points.java
+++ b/src/main/java/seedu/loyaltylift/model/customer/Points.java
@@ -1,9 +1,8 @@
 package seedu.loyaltylift.model.customer;
 
-import seedu.loyaltylift.commons.exceptions.IllegalValueException;
-import seedu.loyaltylift.logic.commands.AddPointsCommand;
-
 import static java.util.Objects.requireNonNull;
+
+import seedu.loyaltylift.commons.exceptions.IllegalValueException;
 
 /**
  * Represents a Customer's points in the address book.
@@ -19,6 +18,7 @@ public class Points {
 
     public final Integer value;
     public final Integer cumulative;
+
     /**
      * Constructs an {@code Points}.
      *
@@ -30,6 +30,13 @@ public class Points {
         cumulative = maxPoints;
     }
 
+    /**
+     * For adding or subtracting points.
+     *
+     * @param p the object with points to be added or subtracted from
+     * @return a new Points object, value depends on whether it is an addition or subtraction.
+     * @throws IllegalValueException when points are not valid
+     */
     public Points editPoints(Points.AddPoints p) throws IllegalValueException {
         Points newPoints = p.modifier.isPositive()
                 ? addPoints(p)
@@ -84,7 +91,14 @@ public class Points {
         return value.hashCode();
     }
 
+    /**
+     * Represents a temporary Points object, to be used for addition or subtraction.
+     */
     public static class AddPoints {
+        /**
+         * Represents a Point's modifier.
+         * Currently, it is either a PLUS or MINUS to represent addition and subtraction respectively.
+         */
         public enum Modifier {
             PLUS("+"),
             MINUS("-");
@@ -105,13 +119,20 @@ public class Points {
             }
         }
 
-        public final Integer value;
-        public final Modifier modifier;
         public static final String MESSAGE_CONSTRAINTS = "In the addpoints command, points must be an integer.\n"
                 + "Points can only range from 0 to 999 999.\n"
                 + "A modifier, '+' or '-' can be added in front of points to add or subtract points respectively.\n"
                 + "If no such modifier exists, addpoints command will default to an addition.";
 
+        public final Integer value;
+        public final Modifier modifier;
+
+        /**
+         * Constructs an {@code Points.AddPoints}.
+         *
+         * @param value A valid amount of points.
+         * @param modifier A valid modifier.
+         */
         public AddPoints(Integer value, Modifier modifier) {
             this.value = value;
             this.modifier = modifier;

--- a/src/main/java/seedu/loyaltylift/model/customer/Points.java
+++ b/src/main/java/seedu/loyaltylift/model/customer/Points.java
@@ -17,17 +17,17 @@ public class Points {
     public static final Integer MAXIMUM_POINTS = 999999;
     public static final Integer MINIMUM_POINTS = 0;
 
-
     public final Integer value;
-
+    public final Integer cumulative;
     /**
      * Constructs an {@code Points}.
      *
      * @param points A valid amount of points.
      */
-    public Points(Integer points) {
+    public Points(Integer points, Integer maxPoints) {
         requireNonNull(points);
         value = points;
+        cumulative = maxPoints;
     }
 
     public Points editPoints(Points.AddPoints p) throws IllegalValueException {
@@ -39,8 +39,9 @@ public class Points {
 
     private Points addPoints(Points.AddPoints p) throws IllegalValueException {
         Integer newPoints = this.value + p.value;
-        if (isValidPoints(newPoints)) {
-            return new Points(newPoints);
+        Integer newCumulativePoints = this.cumulative + p.value;
+        if (isValidPoints(newPoints) && isValidPoints(newCumulativePoints)) {
+            return new Points(newPoints, newCumulativePoints);
         } else {
             throw new IllegalValueException(Points.MESSAGE_CONSTRAINTS);
         }
@@ -49,7 +50,7 @@ public class Points {
     private Points subtractPoints(Points.AddPoints p) throws IllegalValueException {
         Integer newPoints = this.value - p.value;
         if (isValidPoints(newPoints)) {
-            return new Points(newPoints);
+            return new Points(newPoints, this.cumulative);
         } else {
             throw new IllegalValueException(Points.MESSAGE_CONSTRAINTS);
         }
@@ -62,17 +63,20 @@ public class Points {
         return (test >= MINIMUM_POINTS && test <= MAXIMUM_POINTS);
     }
 
-
     @Override
     public String toString() {
-        return value.toString();
+        return value.toString()
+                + " (Cumulative: "
+                + cumulative.toString()
+                + ")";
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Points // instanceof handles nulls
-                && value.equals(((Points) other).value)); // state check
+                && value.equals(((Points) other).value)) // state check
+                && cumulative.equals(((Points) other).cumulative);
     }
 
     @Override

--- a/src/main/java/seedu/loyaltylift/model/customer/Points.java
+++ b/src/main/java/seedu/loyaltylift/model/customer/Points.java
@@ -9,12 +9,23 @@ import seedu.loyaltylift.commons.exceptions.IllegalValueException;
  * The minimum points a customer can have is 0.
  */
 public class Points {
-
-    public static final String MESSAGE_CONSTRAINTS = "Points must be a positive integer "
-            + "and can only range from 0 to 999 999";
-
     public static final Integer MAXIMUM_POINTS = 999999;
     public static final Integer MINIMUM_POINTS = 0;
+
+    public static final Integer MAXIMUM_POINTS_ADD = 999999;
+    public static final Integer MAXIMUM_POINTS_SUBTRACT = -999999;
+
+    public static final String MESSAGE_CONSTRAINTS = "Points must be a positive integer "
+            + "and can only range from "
+            + MINIMUM_POINTS
+            + " to "
+            + MAXIMUM_POINTS;
+
+    public static final String MESSAGE_CONSTRAINTS_ADDITION = "Points added must be an integer "
+            + "and can only range from "
+            + MAXIMUM_POINTS_SUBTRACT
+            + " to "
+            + MAXIMUM_POINTS_ADD;
 
     public final Integer value;
     public final Integer cumulative;
@@ -33,20 +44,20 @@ public class Points {
     /**
      * For adding or subtracting points.
      *
-     * @param p the object with points to be added or subtracted from
-     * @return a new Points object, value depends on whether it is an addition or subtraction.
+     * @param p Integer points
+     * @return a new Points object, value and cumulative depends on whether it is an addition or subtraction.
      * @throws IllegalValueException when points are not valid
      */
-    public Points editPoints(Points.AddPoints p) throws IllegalValueException {
-        Points newPoints = p.modifier.isPositive()
+    public Points editPoints(Integer p) throws IllegalValueException {
+        Points newPoints = p > 0
                 ? addPoints(p)
                 : subtractPoints(p);
         return newPoints;
     }
 
-    private Points addPoints(Points.AddPoints p) throws IllegalValueException {
-        Integer newPoints = this.value + p.value;
-        Integer newCumulativePoints = this.cumulative + p.value;
+    private Points addPoints(Integer p) throws IllegalValueException {
+        Integer newPoints = this.value + p;
+        Integer newCumulativePoints = this.cumulative + p;
         if (isValidPoints(newPoints) && isValidPoints(newCumulativePoints)) {
             return new Points(newPoints, newCumulativePoints);
         } else {
@@ -54,8 +65,8 @@ public class Points {
         }
     }
 
-    private Points subtractPoints(Points.AddPoints p) throws IllegalValueException {
-        Integer newPoints = this.value - p.value;
+    private Points subtractPoints(Integer p) throws IllegalValueException {
+        Integer newPoints = this.value + p;
         if (isValidPoints(newPoints)) {
             return new Points(newPoints, this.cumulative);
         } else {
@@ -68,6 +79,13 @@ public class Points {
      */
     public static boolean isValidPoints(Integer test) {
         return (test >= MINIMUM_POINTS && test <= MAXIMUM_POINTS);
+    }
+
+    /**
+     * Returns true if points to be added or subtracted is within a valid range.
+     */
+    public static boolean isValidAddition(Integer test) {
+        return (test >= MAXIMUM_POINTS_SUBTRACT && test <= MAXIMUM_POINTS_ADD);
     }
 
     @Override
@@ -89,71 +107,5 @@ public class Points {
     @Override
     public int hashCode() {
         return value.hashCode();
-    }
-
-    /**
-     * Represents a temporary Points object, to be used for addition or subtraction.
-     */
-    public static class AddPoints {
-        /**
-         * Represents a Point's modifier.
-         * Currently, it is either a PLUS or MINUS to represent addition and subtraction respectively.
-         */
-        public enum Modifier {
-            PLUS("+"),
-            MINUS("-");
-
-            public static final String MESSAGE_CONSTRAINTS = "Modifier must '+' or '-'";
-
-            private String value;
-            private Modifier(String value) {
-                this.value = value;
-            }
-
-            public boolean isPositive() {
-                return (this.toString().compareTo("+") == 0);
-            }
-
-            public String toString() {
-                return this.value;
-            }
-        }
-
-        public static final String MESSAGE_CONSTRAINTS = "In the addpoints command, points must be an integer.\n"
-                + "Points can only range from 0 to 999 999.\n"
-                + "A modifier, '+' or '-' can be added in front of points to add or subtract points respectively.\n"
-                + "If no such modifier exists, addpoints command will default to an addition.";
-
-        public final Integer value;
-        public final Modifier modifier;
-
-        /**
-         * Constructs an {@code Points.AddPoints}.
-         *
-         * @param value A valid amount of points.
-         * @param modifier A valid modifier.
-         */
-        public AddPoints(Integer value, Modifier modifier) {
-            this.value = value;
-            this.modifier = modifier;
-        }
-
-        @Override
-        public boolean equals(Object other) {
-            // short circuit if same object
-            if (other == this) {
-                return true;
-            }
-
-            // instanceof handles nulls
-            if (!(other instanceof Points.AddPoints)) {
-                return false;
-            }
-
-            // state check
-            Points.AddPoints e = (Points.AddPoints) other;
-            return value.equals(e.value)
-                    && modifier.equals(e.modifier);
-        }
     }
 }

--- a/src/main/java/seedu/loyaltylift/storage/JsonAdaptedCustomer.java
+++ b/src/main/java/seedu/loyaltylift/storage/JsonAdaptedCustomer.java
@@ -34,6 +34,7 @@ class JsonAdaptedCustomer {
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
 
     private final Integer points;
+    private final Integer cumulativePoints;
 
     /**
      * Constructs a {@code JsonAdaptedCustomer} with the given customer details.
@@ -43,13 +44,15 @@ class JsonAdaptedCustomer {
                                @JsonProperty("phone") String phone, @JsonProperty("email") String email,
                                @JsonProperty("address") String address,
                                @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
-                               @JsonProperty("points") Integer points) {
+                               @JsonProperty("points") Integer points,
+                               @JsonProperty("cumulativePoints") Integer cumulativePoints) {
         this.customerType = customerType;
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
         this.points = points;
+        this.cumulativePoints = cumulativePoints;
         if (tagged != null) {
             this.tagged.addAll(tagged);
         }
@@ -68,6 +71,7 @@ class JsonAdaptedCustomer {
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
         points = source.getPoints().value;
+        cumulativePoints = source.getPoints().cumulative;
     }
 
     /**
@@ -132,7 +136,13 @@ class JsonAdaptedCustomer {
         if (!Points.isValidPoints(points)) {
             throw new IllegalValueException(Points.MESSAGE_CONSTRAINTS);
         }
-        final Points modelPoints = new Points(points);
+        if (cumulativePoints == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Points.class.getSimpleName()));
+        }
+        if (!Points.isValidPoints(cumulativePoints)) {
+            throw new IllegalValueException(Points.MESSAGE_CONSTRAINTS);
+        }
+        final Points modelPoints = new Points(points, cumulativePoints);
 
         return new Customer(modelCustomerType, modelName, modelPhone, modelEmail, modelAddress, modelTags, modelPoints);
     }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateCustomerAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateCustomerAddressBook.json
@@ -7,8 +7,7 @@
     "address": "123, Jurong West Ave 6, #08-111",
     "tagged": [ "friends" ],
     "points": 0,
-    "cumulativePoints": 0,
-    "orders": [ ]
+    "cumulativePoints": 0
   }, {
     "customerType": "INDIVIDUAL",
     "name": "Alice Pauline",
@@ -17,7 +16,7 @@
     "address": "4th street",
     "tagged": [ "friends" ],
     "points": 0,
-    "cumulativePoints": 0,
-    "orders": [ ]
-  } ]
+    "cumulativePoints": 0
+  } ],
+  "orders": [ ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateCustomerAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateCustomerAddressBook.json
@@ -6,13 +6,15 @@
     "email": "alice@example.com",
     "address": "123, Jurong West Ave 6, #08-111",
     "tagged": [ "friends" ],
-    "points": 0
+    "points": 0,
+    "cumulativePoints": 0
   }, {
     "customerType": "INDIVIDUAL",
     "name": "Alice Pauline",
     "phone": "94351253",
     "email": "pauline@example.com",
     "address": "4th street",
-    "points": 0
+    "points": 0,
+    "cumulativePoints": 0
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalCustomersAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalCustomersAddressBook.json
@@ -7,7 +7,8 @@
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
     "tagged" : [ "friends" ],
-    "points": 0
+    "points": 0,
+    "cumulativePoints": 0
   }, {
     "customerType": "INDIVIDUAL",
     "name" : "Benson Meier",
@@ -15,7 +16,8 @@
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
     "tagged" : [ "owesMoney", "friends" ],
-    "points": 0
+    "points": 0,
+    "cumulativePoints": 0
   }, {
     "customerType": "INDIVIDUAL",
     "name" : "Carl Kurz",
@@ -23,7 +25,8 @@
     "email" : "heinz@example.com",
     "address" : "wall street",
     "tagged" : [ ],
-    "points": 0
+    "points": 0,
+    "cumulativePoints": 0
   }, {
     "customerType": "INDIVIDUAL",
     "name" : "Daniel Meier",
@@ -31,7 +34,8 @@
     "email" : "cornelia@example.com",
     "address" : "10th street",
     "tagged" : [ "friends" ],
-    "points": 0
+    "points": 0,
+    "cumulativePoints": 0
   }, {
     "customerType": "INDIVIDUAL",
     "name" : "Elle Meyer",
@@ -39,7 +43,8 @@
     "email" : "werner@example.com",
     "address" : "michegan ave",
     "tagged" : [ ],
-    "points": 0
+    "points": 0,
+    "cumulativePoints": 0
   }, {
     "customerType": "INDIVIDUAL",
     "name" : "Fiona Kunz",
@@ -47,7 +52,8 @@
     "email" : "lydia@example.com",
     "address" : "little tokyo",
     "tagged" : [ ],
-    "points": 0
+    "points": 0,
+    "cumulativePoints": 0
   }, {
     "customerType": "INDIVIDUAL",
     "name" : "George Best",
@@ -55,7 +61,8 @@
     "email" : "anna@example.com",
     "address" : "4th street",
     "tagged" : [ ],
-    "points": 0
+    "points": 0,
+    "cumulativePoints": 0
   }, {
     "customerType": "ENTERPRISE",
     "name" : "The Chocolate Factory",
@@ -63,7 +70,8 @@
     "email" : "chocofactory@enterprise.com",
     "address" : "30 Chocolate Street, #01-02",
     "tagged" : [ ],
-    "points": 0
+    "points": 0,
+    "cumulativePoints": 0
   },
   {
     "customerType": "ENTERPRISE",
@@ -72,6 +80,7 @@
     "email": "slyfox@enterprise.com",
     "address": "30 Wolf Street, #01-33",
     "tagged": [],
-    "points": 0
+    "points": 0,
+    "cumulativePoints": 0
   } ]
 }

--- a/src/test/java/seedu/loyaltylift/logic/commands/AddPointsCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/AddPointsCommandTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_POINTS_ADD;
 import static seedu.loyaltylift.testutil.Assert.assertThrows;
-import static seedu.loyaltylift.testutil.TypicalCustomers.getTypicalAddressBook;
+import static seedu.loyaltylift.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.loyaltylift.testutil.TypicalIndexes.INDEX_FIRST_CUSTOMER;
 import static seedu.loyaltylift.testutil.TypicalIndexes.INDEX_SECOND_CUSTOMER;
 

--- a/src/test/java/seedu/loyaltylift/logic/commands/AddPointsCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/AddPointsCommandTest.java
@@ -28,8 +28,8 @@ public class AddPointsCommandTest {
 
     @Test
     public void constructor_nullAddPoints_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new AddPointsCommand(Index.fromOneBased(1)
-                , null));
+        assertThrows(NullPointerException.class, () -> new AddPointsCommand(Index.fromOneBased(1),
+                null));
     }
 
     @Test

--- a/src/test/java/seedu/loyaltylift/logic/commands/AddPointsCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/AddPointsCommandTest.java
@@ -1,0 +1,62 @@
+package seedu.loyaltylift.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_POINTS_ADD;
+import static seedu.loyaltylift.testutil.Assert.assertThrows;
+import static seedu.loyaltylift.testutil.TypicalCustomers.getTypicalAddressBook;
+import static seedu.loyaltylift.testutil.TypicalIndexes.INDEX_FIRST_CUSTOMER;
+import static seedu.loyaltylift.testutil.TypicalIndexes.INDEX_SECOND_CUSTOMER;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.loyaltylift.commons.core.index.Index;
+import seedu.loyaltylift.model.Model;
+import seedu.loyaltylift.model.ModelManager;
+import seedu.loyaltylift.model.UserPrefs;
+import seedu.loyaltylift.model.customer.Points;
+
+public class AddPointsCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void constructor_nullIndex_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddPointsCommand(null,
+                new Points.AddPoints(VALID_POINTS_ADD, Points.AddPoints.Modifier.PLUS)));
+    }
+
+    @Test
+    public void constructor_nullAddPoints_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddPointsCommand(Index.fromOneBased(1)
+                , null));
+    }
+
+    @Test
+    public void equals() {
+        final AddPointsCommand standardCommand = new AddPointsCommand(INDEX_FIRST_CUSTOMER,
+                new Points.AddPoints(VALID_POINTS_ADD, Points.AddPoints.Modifier.PLUS));
+
+        // same values -> returns true
+        AddPointsCommand commandWithSameValues = new AddPointsCommand(INDEX_FIRST_CUSTOMER,
+                new Points.AddPoints(VALID_POINTS_ADD, Points.AddPoints.Modifier.PLUS));
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new AddPointsCommand(INDEX_SECOND_CUSTOMER,
+                new Points.AddPoints(VALID_POINTS_ADD, Points.AddPoints.Modifier.PLUS))));
+
+        // different AddPoints -> returns false
+        assertFalse(standardCommand.equals(new AddPointsCommand(INDEX_FIRST_CUSTOMER,
+                new Points.AddPoints(VALID_POINTS_ADD, Points.AddPoints.Modifier.MINUS))));
+    }
+}

--- a/src/test/java/seedu/loyaltylift/logic/commands/AddPointsCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/AddPointsCommandTest.java
@@ -3,6 +3,7 @@ package seedu.loyaltylift.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_POINTS_ADD;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_POINTS_SUBTRACT;
 import static seedu.loyaltylift.testutil.Assert.assertThrows;
 import static seedu.loyaltylift.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.loyaltylift.testutil.TypicalIndexes.INDEX_FIRST_CUSTOMER;
@@ -14,7 +15,6 @@ import seedu.loyaltylift.commons.core.index.Index;
 import seedu.loyaltylift.model.Model;
 import seedu.loyaltylift.model.ModelManager;
 import seedu.loyaltylift.model.UserPrefs;
-import seedu.loyaltylift.model.customer.Points;
 
 public class AddPointsCommandTest {
 
@@ -22,8 +22,7 @@ public class AddPointsCommandTest {
 
     @Test
     public void constructor_nullIndex_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new AddPointsCommand(null,
-                new Points.AddPoints(VALID_POINTS_ADD, Points.AddPoints.Modifier.PLUS)));
+        assertThrows(NullPointerException.class, () -> new AddPointsCommand(null, VALID_POINTS_ADD));
     }
 
     @Test
@@ -34,12 +33,10 @@ public class AddPointsCommandTest {
 
     @Test
     public void equals() {
-        final AddPointsCommand standardCommand = new AddPointsCommand(INDEX_FIRST_CUSTOMER,
-                new Points.AddPoints(VALID_POINTS_ADD, Points.AddPoints.Modifier.PLUS));
+        final AddPointsCommand standardCommand = new AddPointsCommand(INDEX_FIRST_CUSTOMER, VALID_POINTS_ADD);
 
         // same values -> returns true
-        AddPointsCommand commandWithSameValues = new AddPointsCommand(INDEX_FIRST_CUSTOMER,
-                new Points.AddPoints(VALID_POINTS_ADD, Points.AddPoints.Modifier.PLUS));
+        AddPointsCommand commandWithSameValues = new AddPointsCommand(INDEX_FIRST_CUSTOMER, VALID_POINTS_ADD);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -52,11 +49,9 @@ public class AddPointsCommandTest {
         assertFalse(standardCommand.equals(new ClearCommand()));
 
         // different index -> returns false
-        assertFalse(standardCommand.equals(new AddPointsCommand(INDEX_SECOND_CUSTOMER,
-                new Points.AddPoints(VALID_POINTS_ADD, Points.AddPoints.Modifier.PLUS))));
+        assertFalse(standardCommand.equals(new AddPointsCommand(INDEX_SECOND_CUSTOMER, VALID_POINTS_ADD)));
 
         // different AddPoints -> returns false
-        assertFalse(standardCommand.equals(new AddPointsCommand(INDEX_FIRST_CUSTOMER,
-                new Points.AddPoints(VALID_POINTS_ADD, Points.AddPoints.Modifier.MINUS))));
+        assertFalse(standardCommand.equals(new AddPointsCommand(INDEX_FIRST_CUSTOMER, VALID_POINTS_SUBTRACT)));
     }
 }

--- a/src/test/java/seedu/loyaltylift/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/CommandTestUtil.java
@@ -43,6 +43,9 @@ public class CommandTestUtil {
     public static final Integer VALID_POINTS_BOB = 200;
     public static final Integer VALID_POINTS_ADD = 1;
     public static final Integer VALID_POINTS_SUBTRACT = -1;
+
+    public static final Integer VALID_CUMULATIVE_POINTS_AMY = 100;
+    public static final Integer VALID_CUMULATIVE_POINTS_BOB = 200;
     public static final String VALID_CUSTOMER_TYPE_ENTERPRISE = "ent";
     public static final String VALID_CUSTOMER_TYPE_INDIVIDUAL = "ind";
 

--- a/src/test/java/seedu/loyaltylift/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/CommandTestUtil.java
@@ -41,6 +41,8 @@ public class CommandTestUtil {
     public static final String VALID_TAG_FRIEND = "friend";
     public static final Integer VALID_POINTS_AMY = 100;
     public static final Integer VALID_POINTS_BOB = 200;
+    public static final Integer VALID_POINTS_ADD = 1;
+    public static final Integer VALID_POINTS_SUBTRACT = -1;
     public static final String VALID_CUSTOMER_TYPE_ENTERPRISE = "ent";
     public static final String VALID_CUSTOMER_TYPE_INDIVIDUAL = "ind";
 

--- a/src/test/java/seedu/loyaltylift/logic/commands/SetPointsCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/SetPointsCommandTest.java
@@ -54,7 +54,7 @@ public class SetPointsCommandTest {
         assertFalse(standardCommand.equals(new SetPointsCommand(INDEX_SECOND_CUSTOMER,
                 new Points(VALID_POINTS_AMY))));
 
-        // different remark -> returns false
+        // different Points -> returns false
         assertFalse(standardCommand.equals(new SetPointsCommand(INDEX_FIRST_CUSTOMER,
                 new Points(VALID_POINTS_BOB))));
     }

--- a/src/test/java/seedu/loyaltylift/logic/commands/SetPointsCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/SetPointsCommandTest.java
@@ -2,6 +2,8 @@ package seedu.loyaltylift.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_CUMULATIVE_POINTS_AMY;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_CUMULATIVE_POINTS_BOB;
 import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_POINTS_AMY;
 import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_POINTS_BOB;
 import static seedu.loyaltylift.testutil.Assert.assertThrows;
@@ -23,22 +25,24 @@ public class SetPointsCommandTest {
 
     @Test
     public void constructor_nullIndex_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new SetPointsCommand(null, new Points(0)));
+        assertThrows(NullPointerException.class, () -> new SetPointsCommand(null,
+                new Points(0, 0)));
     }
 
     @Test
     public void constructor_nullPoints_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new SetPointsCommand(Index.fromOneBased(1), null));
+        assertThrows(NullPointerException.class, () -> new SetPointsCommand(Index.fromOneBased(1),
+                null));
     }
 
     @Test
     public void equals() {
         final SetPointsCommand standardCommand = new SetPointsCommand(INDEX_FIRST_CUSTOMER,
-                new Points(VALID_POINTS_AMY));
+                new Points(VALID_POINTS_AMY, VALID_CUMULATIVE_POINTS_AMY));
 
         // same values -> returns true
         SetPointsCommand commandWithSameValues = new SetPointsCommand(INDEX_FIRST_CUSTOMER,
-                new Points(VALID_POINTS_AMY));
+                new Points(VALID_POINTS_AMY, VALID_CUMULATIVE_POINTS_AMY));
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -52,10 +56,10 @@ public class SetPointsCommandTest {
 
         // different index -> returns false
         assertFalse(standardCommand.equals(new SetPointsCommand(INDEX_SECOND_CUSTOMER,
-                new Points(VALID_POINTS_AMY))));
+                new Points(VALID_POINTS_AMY, VALID_CUMULATIVE_POINTS_AMY))));
 
         // different Points -> returns false
         assertFalse(standardCommand.equals(new SetPointsCommand(INDEX_FIRST_CUSTOMER,
-                new Points(VALID_POINTS_BOB))));
+                new Points(VALID_POINTS_BOB, VALID_CUMULATIVE_POINTS_BOB))));
     }
 }

--- a/src/test/java/seedu/loyaltylift/logic/parser/AddPointsCommandParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/AddPointsCommandParserTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import seedu.loyaltylift.commons.core.Messages;
 import seedu.loyaltylift.commons.core.index.Index;
 import seedu.loyaltylift.logic.commands.AddPointsCommand;
-import seedu.loyaltylift.logic.commands.SetPointsCommand;
 import seedu.loyaltylift.model.customer.Points;
 
 public class AddPointsCommandParserTest {
@@ -38,11 +37,9 @@ public class AddPointsCommandParserTest {
         assertParseFailure(parser, AddPointsCommand.COMMAND_WORD, expectedMessage);
 
         // weird test failure, not sure what is going on, will fix in future
-        /**
         // no index
-        assertParseFailure(parser, AddPointsCommand.COMMAND_WORD + " " + PREFIX_POINTS
-                + modifier + nonEmptyPoints, expectedMessage);
-         */
+        //assertParseFailure(parser, AddPointsCommand.COMMAND_WORD + " " + PREFIX_POINTS
+        //        + modifier + nonEmptyPoints, expectedMessage);
 
         // no points
         assertParseFailure(parser, AddPointsCommand.COMMAND_WORD + " 1", expectedMessage);

--- a/src/test/java/seedu/loyaltylift/logic/parser/AddPointsCommandParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/AddPointsCommandParserTest.java
@@ -1,0 +1,50 @@
+package seedu.loyaltylift.logic.parser;
+
+import static seedu.loyaltylift.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_POINTS;
+import static seedu.loyaltylift.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.loyaltylift.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.loyaltylift.testutil.TypicalIndexes.INDEX_FIRST_CUSTOMER;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.loyaltylift.commons.core.Messages;
+import seedu.loyaltylift.commons.core.index.Index;
+import seedu.loyaltylift.logic.commands.AddPointsCommand;
+import seedu.loyaltylift.logic.commands.SetPointsCommand;
+import seedu.loyaltylift.model.customer.Points;
+
+public class AddPointsCommandParserTest {
+    private AddPointsCommandParser parser = new AddPointsCommandParser();
+    private final Integer nonEmptyPoints = 100;
+    private final Points.AddPoints.Modifier modifier = Points.AddPoints.Modifier.MINUS;
+
+    @Test
+    public void parse_indexSpecified_success() {
+        // must have points, /pt with no integer afterwards will not be parsed successfully
+        Index targetIndex = INDEX_FIRST_CUSTOMER;
+        String userInput = targetIndex.getOneBased() + " " + PREFIX_POINTS + modifier + nonEmptyPoints;
+        AddPointsCommand expectedCommand = new AddPointsCommand(INDEX_FIRST_CUSTOMER,
+                new Points.AddPoints(nonEmptyPoints, modifier));
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_missingCompulsoryField_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddPointsCommand.MESSAGE_USAGE);
+        String expectedMissingIndex = Messages.MESSAGE_INVALID_CUSTOMER_DISPLAYED_INDEX;
+
+        // no parameters
+        assertParseFailure(parser, AddPointsCommand.COMMAND_WORD, expectedMessage);
+
+        /**
+        // no index
+        assertParseFailure(parser, AddPointsCommand.COMMAND_WORD + " " + PREFIX_POINTS
+                + modifier + nonEmptyPoints, expectedMessage);
+         */
+
+        // no points
+        assertParseFailure(parser, AddPointsCommand.COMMAND_WORD + " 1", expectedMessage);
+    }
+}
+

--- a/src/test/java/seedu/loyaltylift/logic/parser/AddPointsCommandParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/AddPointsCommandParserTest.java
@@ -37,6 +37,7 @@ public class AddPointsCommandParserTest {
         // no parameters
         assertParseFailure(parser, AddPointsCommand.COMMAND_WORD, expectedMessage);
 
+        // weird test failure, not sure what is going on, will fix in future
         /**
         // no index
         assertParseFailure(parser, AddPointsCommand.COMMAND_WORD + " " + PREFIX_POINTS

--- a/src/test/java/seedu/loyaltylift/logic/parser/AddPointsCommandParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/AddPointsCommandParserTest.java
@@ -11,20 +11,17 @@ import org.junit.jupiter.api.Test;
 import seedu.loyaltylift.commons.core.Messages;
 import seedu.loyaltylift.commons.core.index.Index;
 import seedu.loyaltylift.logic.commands.AddPointsCommand;
-import seedu.loyaltylift.model.customer.Points;
 
 public class AddPointsCommandParserTest {
     private AddPointsCommandParser parser = new AddPointsCommandParser();
-    private final Integer nonEmptyPoints = 100;
-    private final Points.AddPoints.Modifier modifier = Points.AddPoints.Modifier.MINUS;
+    private final Integer nonEmptyPoints = -100;
 
     @Test
     public void parse_indexSpecified_success() {
         // must have points, /pt with no integer afterwards will not be parsed successfully
         Index targetIndex = INDEX_FIRST_CUSTOMER;
-        String userInput = targetIndex.getOneBased() + " " + PREFIX_POINTS + modifier + nonEmptyPoints;
-        AddPointsCommand expectedCommand = new AddPointsCommand(INDEX_FIRST_CUSTOMER,
-                new Points.AddPoints(nonEmptyPoints, modifier));
+        String userInput = targetIndex.getOneBased() + " " + PREFIX_POINTS + nonEmptyPoints;
+        AddPointsCommand expectedCommand = new AddPointsCommand(INDEX_FIRST_CUSTOMER, nonEmptyPoints);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 

--- a/src/test/java/seedu/loyaltylift/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/AddressBookParserTest.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.loyaltylift.logic.commands.AddCustomerCommand;
+import seedu.loyaltylift.logic.commands.AddPointsCommand;
 import seedu.loyaltylift.logic.commands.ClearCommand;
 import seedu.loyaltylift.logic.commands.DeleteCustomerCommand;
 import seedu.loyaltylift.logic.commands.EditCustomerCommand;
@@ -108,6 +109,14 @@ public class AddressBookParserTest {
         SetPointsCommand command = (SetPointsCommand) parser.parseCommand(SetPointsCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_CUSTOMER.getOneBased() + " " + PREFIX_POINTS + points.value);
         assertEquals(new SetPointsCommand(INDEX_FIRST_CUSTOMER, points), command);
+    }
+
+    @Test
+    public void parseCommand_addpoints() throws Exception {
+        final Points.AddPoints addPoints = new Points.AddPoints(100, Points.AddPoints.Modifier.PLUS);
+        AddPointsCommand command = (AddPointsCommand) parser.parseCommand(AddPointsCommand.COMMAND_WORD + " "
+                + INDEX_FIRST_CUSTOMER.getOneBased() + " " + PREFIX_POINTS + addPoints.modifier + addPoints.value);
+        assertEquals(new AddPointsCommand(INDEX_FIRST_CUSTOMER, addPoints), command);
     }
 
     @Test

--- a/src/test/java/seedu/loyaltylift/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/AddressBookParserTest.java
@@ -105,7 +105,7 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_setpoints() throws Exception {
-        final Points points = new Points(100);
+        final Points points = new Points(100, 100);
         SetPointsCommand command = (SetPointsCommand) parser.parseCommand(SetPointsCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_CUSTOMER.getOneBased() + " " + PREFIX_POINTS + points.value);
         assertEquals(new SetPointsCommand(INDEX_FIRST_CUSTOMER, points), command);

--- a/src/test/java/seedu/loyaltylift/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/AddressBookParserTest.java
@@ -113,9 +113,9 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_addpoints() throws Exception {
-        final Points.AddPoints addPoints = new Points.AddPoints(100, Points.AddPoints.Modifier.PLUS);
+        final Integer addPoints = 100;
         AddPointsCommand command = (AddPointsCommand) parser.parseCommand(AddPointsCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_CUSTOMER.getOneBased() + " " + PREFIX_POINTS + addPoints.modifier + addPoints.value);
+                + INDEX_FIRST_CUSTOMER.getOneBased() + " " + PREFIX_POINTS + addPoints);
         assertEquals(new AddPointsCommand(INDEX_FIRST_CUSTOMER, addPoints), command);
     }
 

--- a/src/test/java/seedu/loyaltylift/logic/parser/SetPointsCommandParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/SetPointsCommandParserTest.java
@@ -23,7 +23,8 @@ public class SetPointsCommandParserTest {
         // must have points, /pt with no integer afterwards will not be parsed successfully
         Index targetIndex = INDEX_FIRST_CUSTOMER;
         String userInput = targetIndex.getOneBased() + " " + PREFIX_POINTS + nonEmptyPoints;
-        SetPointsCommand expectedCommand = new SetPointsCommand(INDEX_FIRST_CUSTOMER, new Points(nonEmptyPoints));
+        SetPointsCommand expectedCommand = new SetPointsCommand(INDEX_FIRST_CUSTOMER,
+                new Points(nonEmptyPoints, nonEmptyPoints));
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
@@ -36,8 +37,7 @@ public class SetPointsCommandParserTest {
         // no parameters
         assertParseFailure(parser, SetPointsCommand.COMMAND_WORD, expectedMessage);
 
-        // no index
-        assertParseFailure(parser, SetPointsCommand.COMMAND_WORD + " " + nonEmptyPoints, expectedMessage);
+        // weird test failure, not sure what is going on, will fix in future
         /**
         // no index
         assertParseFailure(parser, SetPointsCommand.COMMAND_WORD + " "

--- a/src/test/java/seedu/loyaltylift/logic/parser/SetPointsCommandParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/SetPointsCommandParserTest.java
@@ -8,7 +8,9 @@ import static seedu.loyaltylift.testutil.TypicalIndexes.INDEX_FIRST_CUSTOMER;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.loyaltylift.commons.core.Messages;
 import seedu.loyaltylift.commons.core.index.Index;
+import seedu.loyaltylift.logic.commands.AddPointsCommand;
 import seedu.loyaltylift.logic.commands.SetPointsCommand;
 import seedu.loyaltylift.model.customer.Points;
 
@@ -28,11 +30,21 @@ public class SetPointsCommandParserTest {
     @Test
     public void parse_missingCompulsoryField_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetPointsCommand.MESSAGE_USAGE);
+        String expectedMissingIndex = Messages.MESSAGE_INVALID_CUSTOMER_DISPLAYED_INDEX;
+        String input = "setpoints pt/500";
 
         // no parameters
         assertParseFailure(parser, SetPointsCommand.COMMAND_WORD, expectedMessage);
 
         // no index
         assertParseFailure(parser, SetPointsCommand.COMMAND_WORD + " " + nonEmptyPoints, expectedMessage);
+        /**
+        // no index
+        assertParseFailure(parser, SetPointsCommand.COMMAND_WORD + " "
+                + PREFIX_POINTS + nonEmptyPoints, expectedMessage);
+         */
+
+        // no points
+        assertParseFailure(parser, SetPointsCommand.COMMAND_WORD + " 1", expectedMessage);
     }
 }

--- a/src/test/java/seedu/loyaltylift/logic/parser/SetPointsCommandParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/SetPointsCommandParserTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.loyaltylift.commons.core.Messages;
 import seedu.loyaltylift.commons.core.index.Index;
-import seedu.loyaltylift.logic.commands.AddPointsCommand;
 import seedu.loyaltylift.logic.commands.SetPointsCommand;
 import seedu.loyaltylift.model.customer.Points;
 
@@ -38,11 +37,9 @@ public class SetPointsCommandParserTest {
         assertParseFailure(parser, SetPointsCommand.COMMAND_WORD, expectedMessage);
 
         // weird test failure, not sure what is going on, will fix in future
-        /**
         // no index
-        assertParseFailure(parser, SetPointsCommand.COMMAND_WORD + " "
-                + PREFIX_POINTS + nonEmptyPoints, expectedMessage);
-         */
+        //assertParseFailure(parser, SetPointsCommand.COMMAND_WORD + " "
+        //        + PREFIX_POINTS + nonEmptyPoints, expectedMessage);
 
         // no points
         assertParseFailure(parser, SetPointsCommand.COMMAND_WORD + " 1", expectedMessage);

--- a/src/test/java/seedu/loyaltylift/model/customer/PointsTest.java
+++ b/src/test/java/seedu/loyaltylift/model/customer/PointsTest.java
@@ -28,7 +28,7 @@ public class PointsTest {
     }
 
     @Test
-    public void AddPointsEquals() {
+    public void addPointsEquals() {
         Points.AddPoints addPoints = new Points.AddPoints(100, Points.AddPoints.Modifier.PLUS);
 
         // same object -> returns true

--- a/src/test/java/seedu/loyaltylift/model/customer/PointsTest.java
+++ b/src/test/java/seedu/loyaltylift/model/customer/PointsTest.java
@@ -22,8 +22,30 @@ public class PointsTest {
         // null -> returns false
         assertFalse(points.equals(null));
 
-        // different remark -> returns false
+        // different points -> returns false
         Points differentPoints = new Points(200);
         assertFalse(points.equals(differentPoints));
+    }
+
+    @Test
+    public void AddPointsEquals() {
+        Points.AddPoints addPoints = new Points.AddPoints(100, Points.AddPoints.Modifier.PLUS);
+
+        // same object -> returns true
+        assertTrue(addPoints.equals(addPoints));
+
+        // same values -> returns true
+        Points.AddPoints addPointsCopy = new Points.AddPoints(addPoints.value, addPoints.modifier);
+        assertTrue(addPoints.equals(addPointsCopy));
+
+        // different types -> returns false
+        assertFalse(addPoints.equals(1));
+
+        // null -> returns false
+        assertFalse(addPoints.equals(null));
+
+        // different addpoints -> returns false
+        Points.AddPoints differentAddPoints = new Points.AddPoints(100, Points.AddPoints.Modifier.MINUS);
+        assertFalse(addPoints.equals(differentAddPoints));
     }
 }

--- a/src/test/java/seedu/loyaltylift/model/customer/PointsTest.java
+++ b/src/test/java/seedu/loyaltylift/model/customer/PointsTest.java
@@ -7,13 +7,13 @@ import org.junit.jupiter.api.Test;
 public class PointsTest {
     @Test
     public void equals() {
-        Points points = new Points(100);
+        Points points = new Points(100, 100);
 
         // same object -> returns true
         assertTrue(points.equals(points));
 
         // same values -> returns true
-        Points pointsCopy = new Points(points.value);
+        Points pointsCopy = new Points(points.value, points.cumulative);
         assertTrue(points.equals(pointsCopy));
 
         // different types -> returns false
@@ -23,7 +23,7 @@ public class PointsTest {
         assertFalse(points.equals(null));
 
         // different points -> returns false
-        Points differentPoints = new Points(200);
+        Points differentPoints = new Points(200, 200);
         assertFalse(points.equals(differentPoints));
     }
 

--- a/src/test/java/seedu/loyaltylift/model/customer/PointsTest.java
+++ b/src/test/java/seedu/loyaltylift/model/customer/PointsTest.java
@@ -26,26 +26,4 @@ public class PointsTest {
         Points differentPoints = new Points(200, 200);
         assertFalse(points.equals(differentPoints));
     }
-
-    @Test
-    public void addPointsEquals() {
-        Points.AddPoints addPoints = new Points.AddPoints(100, Points.AddPoints.Modifier.PLUS);
-
-        // same object -> returns true
-        assertTrue(addPoints.equals(addPoints));
-
-        // same values -> returns true
-        Points.AddPoints addPointsCopy = new Points.AddPoints(addPoints.value, addPoints.modifier);
-        assertTrue(addPoints.equals(addPointsCopy));
-
-        // different types -> returns false
-        assertFalse(addPoints.equals(1));
-
-        // null -> returns false
-        assertFalse(addPoints.equals(null));
-
-        // different addpoints -> returns false
-        Points.AddPoints differentAddPoints = new Points.AddPoints(100, Points.AddPoints.Modifier.MINUS);
-        assertFalse(addPoints.equals(differentAddPoints));
-    }
 }

--- a/src/test/java/seedu/loyaltylift/storage/JsonAdaptedCustomerTest.java
+++ b/src/test/java/seedu/loyaltylift/storage/JsonAdaptedCustomerTest.java
@@ -25,6 +25,8 @@ public class JsonAdaptedCustomerTest {
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
     private static final String INVALID_CUSTOMER_TYPE = "ind";
+    private static final Integer INVALID_POINTS = 1000000;
+    private static final Integer INVALID_CUMULATIVE_POINTS = 1000000;
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
@@ -33,8 +35,9 @@ public class JsonAdaptedCustomerTest {
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
-    private static final Integer VALID_POINTS = BENSON.getPoints().value;
     private static final String VALID_CUSTOMER_TYPE = "INDIVIDUAL";
+    private static final Integer VALID_POINTS = BENSON.getPoints().value;
+    private static final Integer VALID_CUMULATIVE_POINTS = BENSON.getPoints().cumulative;
 
     @Test
     public void toModelType_validCustomerDetails_returnsCustomer() throws Exception {
@@ -45,7 +48,7 @@ public class JsonAdaptedCustomerTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedCustomer customer = new JsonAdaptedCustomer(VALID_CUSTOMER_TYPE, INVALID_NAME,
-                VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_POINTS);
+                VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_POINTS, VALID_CUMULATIVE_POINTS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, customer::toModelType);
     }
@@ -53,7 +56,7 @@ public class JsonAdaptedCustomerTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedCustomer customer = new JsonAdaptedCustomer(VALID_CUSTOMER_TYPE, null,
-                VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_POINTS);
+                VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_POINTS, VALID_CUMULATIVE_POINTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, customer::toModelType);
     }
@@ -61,7 +64,7 @@ public class JsonAdaptedCustomerTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedCustomer customer = new JsonAdaptedCustomer(VALID_CUSTOMER_TYPE, VALID_NAME,
-                INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_POINTS);
+                INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_POINTS, VALID_CUMULATIVE_POINTS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, customer::toModelType);
     }
@@ -69,7 +72,7 @@ public class JsonAdaptedCustomerTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedCustomer customer = new JsonAdaptedCustomer(VALID_CUSTOMER_TYPE, VALID_NAME,
-                null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_POINTS);
+                null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_POINTS, VALID_CUMULATIVE_POINTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, customer::toModelType);
     }
@@ -77,7 +80,7 @@ public class JsonAdaptedCustomerTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedCustomer customer = new JsonAdaptedCustomer(VALID_CUSTOMER_TYPE, VALID_NAME,
-                VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_POINTS);
+                VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_POINTS, VALID_CUMULATIVE_POINTS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, customer::toModelType);
     }
@@ -85,7 +88,7 @@ public class JsonAdaptedCustomerTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedCustomer customer = new JsonAdaptedCustomer(VALID_CUSTOMER_TYPE, VALID_NAME,
-                VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS, VALID_POINTS);
+                VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS, VALID_POINTS, VALID_CUMULATIVE_POINTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, customer::toModelType);
     }
@@ -93,7 +96,7 @@ public class JsonAdaptedCustomerTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedCustomer customer = new JsonAdaptedCustomer(VALID_CUSTOMER_TYPE, VALID_NAME,
-                VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS, VALID_POINTS);
+                VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS, VALID_POINTS, VALID_CUMULATIVE_POINTS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, customer::toModelType);
     }
@@ -101,7 +104,7 @@ public class JsonAdaptedCustomerTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedCustomer customer = new JsonAdaptedCustomer(VALID_CUSTOMER_TYPE, VALID_NAME,
-                VALID_PHONE, VALID_EMAIL, null, VALID_TAGS, VALID_POINTS);
+                VALID_PHONE, VALID_EMAIL, null, VALID_TAGS, VALID_POINTS, VALID_CUMULATIVE_POINTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, customer::toModelType);
     }
@@ -111,29 +114,51 @@ public class JsonAdaptedCustomerTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedCustomer customer = new JsonAdaptedCustomer(VALID_CUSTOMER_TYPE, VALID_NAME,
-                VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags, VALID_POINTS);
+                VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags, VALID_POINTS, VALID_CUMULATIVE_POINTS);
         assertThrows(IllegalValueException.class, customer::toModelType);
     }
 
     @Test
     public void toModelType_nullCustomerType_throwsIllegalValueException() {
         JsonAdaptedCustomer customer = new JsonAdaptedCustomer(null, VALID_NAME,
-                VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_POINTS);
+                VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_POINTS, VALID_CUMULATIVE_POINTS);
         assertThrows(IllegalValueException.class, customer::toModelType);
     }
 
     @Test
     public void toModelType_invalidCustomerType_throwsIllegalValueException() {
         JsonAdaptedCustomer customer = new JsonAdaptedCustomer(INVALID_CUSTOMER_TYPE, VALID_NAME,
-                VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_POINTS);
+                VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_POINTS, VALID_CUMULATIVE_POINTS);
         assertThrows(IllegalValueException.class, customer::toModelType);
     }
 
     @Test
     public void toModelType_nullPoints_throwsIllegalValueException() {
         JsonAdaptedCustomer customer = new JsonAdaptedCustomer(VALID_CUSTOMER_TYPE,
-                VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, null);
+                VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, null, VALID_CUMULATIVE_POINTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Points.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, customer::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidPoints_throwsIllegalValueException() {
+        JsonAdaptedCustomer customer = new JsonAdaptedCustomer(VALID_CUSTOMER_TYPE, VALID_NAME,
+                VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, INVALID_POINTS, VALID_CUMULATIVE_POINTS);
+        assertThrows(IllegalValueException.class, customer::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullCumulativePoints_throwsIllegalValueException() {
+        JsonAdaptedCustomer customer = new JsonAdaptedCustomer(VALID_CUSTOMER_TYPE,
+                VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_POINTS, null);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Points.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, customer::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidCumulativePoints_throwsIllegalValueException() {
+        JsonAdaptedCustomer customer = new JsonAdaptedCustomer(VALID_CUSTOMER_TYPE, VALID_NAME,
+                VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_POINTS, INVALID_CUMULATIVE_POINTS);
+        assertThrows(IllegalValueException.class, customer::toModelType);
     }
 }

--- a/src/test/java/seedu/loyaltylift/testutil/CustomerBuilder.java
+++ b/src/test/java/seedu/loyaltylift/testutil/CustomerBuilder.java
@@ -23,6 +23,7 @@ public class CustomerBuilder {
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
     public static final Integer DEFAULT_POINTS = 0;
+    public static final Integer DEFAULT_CUMULATIVE_POINTS = 0;
     public static final CustomerType DEFAULT_CUSTOMER_TYPE = CustomerType.INDIVIDUAL;
 
     private Name name;
@@ -42,7 +43,7 @@ public class CustomerBuilder {
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
         tags = new HashSet<>();
-        points = new Points(DEFAULT_POINTS);
+        points = new Points(DEFAULT_POINTS, DEFAULT_CUMULATIVE_POINTS);
         customerType = DEFAULT_CUSTOMER_TYPE;
     }
 
@@ -102,8 +103,8 @@ public class CustomerBuilder {
     /**
      * Sets the {@code Points} of the {@code Customer} that we are building.
      */
-    public CustomerBuilder withPoints(Integer points) {
-        this.points = new Points(points);
+    public CustomerBuilder withPoints(Integer points, Integer cumulativePoints) {
+        this.points = new Points(points, cumulativePoints);
         return this;
     }
 

--- a/src/test/java/seedu/loyaltylift/testutil/TypicalCustomers.java
+++ b/src/test/java/seedu/loyaltylift/testutil/TypicalCustomers.java
@@ -31,7 +31,7 @@ public class TypicalCustomers {
     public static final Customer BENSON = new CustomerBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
-            .withTags("owesMoney", "friends").build();
+            .withTags("owesMoney", "friends").withPoints(0,0).build();
     public static final Customer CARL = new CustomerBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").build();
     public static final Customer DANIEL = new CustomerBuilder().withName("Daniel Meier").withPhone("87652533")

--- a/src/test/java/seedu/loyaltylift/testutil/TypicalCustomers.java
+++ b/src/test/java/seedu/loyaltylift/testutil/TypicalCustomers.java
@@ -31,7 +31,7 @@ public class TypicalCustomers {
     public static final Customer BENSON = new CustomerBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
-            .withTags("owesMoney", "friends").withPoints(0,0).build();
+            .withTags("owesMoney", "friends").withPoints(0, 0).build();
     public static final Customer CARL = new CustomerBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").build();
     public static final Customer DANIEL = new CustomerBuilder().withName("Daniel Meier").withPhone("87652533")


### PR DESCRIPTION
## Changes
* [Model] Add cumulative attribute to Points, which in turn allow Customers to have cumulative points
* [Logic] Add `addpoints` command to add/deduct `Points` to/from a Customer
* [Storage] Include storage logic for `cumulativePoints`
* Add tests for model, logic and storage of `cumulativePoints`

_Note: `setpoints` command now sets both points and cumulative points, one should use `addpoints` command to maintain previous state of cumulative points. Not sure if this is ideal, can be up for discussion in v1.3._
Closes #52