### PR TITLE
Add command to filter orders by name

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -355,7 +355,7 @@ Examples:
 
 ### Locating orders by name: `findo`
 
-Finds persons whose names contain any of the given keywords.
+Finds orders whose names contain any of the given keywords.
 
 Format: `findo KEYWORD [MORE_KEYWORDS]`
 
@@ -363,7 +363,7 @@ Format: `findo KEYWORD [MORE_KEYWORDS]`
 * The order of the keywords does not matter. e.g. `chocolate cake` will match ` cake chocolate`.
 * Only the order name is searched.
 * Only full words will be matched e.g. `chocolate` will not match `chocolatey`
-* Persons matching at least one keyword will be returned (i.e. `OR` search).
+* Orders matching at least one keyword will be returned (i.e. `OR` search).
   e.g. `chocolate cake` will return `chocolate muffin`, `crepe cake`
 
 Examples:

--- a/src/main/java/seedu/loyaltylift/commons/core/Messages.java
+++ b/src/main/java/seedu/loyaltylift/commons/core/Messages.java
@@ -10,5 +10,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_CUSTOMER_DISPLAYED_INDEX = "The customer index provided is invalid";
     public static final String MESSAGE_INVALID_ORDER_DISPLAYED_INDEX = "The order index provided is invalid";
     public static final String MESSAGE_CUSTOMERS_LISTED_OVERVIEW = "%1$d customers listed!";
+    public static final String MESSAGE_ORDERS_LISTED_OVERVIEW = "%1$d orders listed!";
 
 }

--- a/src/main/java/seedu/loyaltylift/logic/commands/FindCustomerCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/FindCustomerCommand.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.loyaltylift.commons.core.Messages;
 import seedu.loyaltylift.model.Model;
-import seedu.loyaltylift.model.customer.NameContainsKeywordsPredicate;
+import seedu.loyaltylift.model.customer.CustomerNameContainsKeywordsPredicate;
 
 /**
  * Finds and lists all customers in address book whose name contains any of the argument keywords.
@@ -19,9 +19,9 @@ public class FindCustomerCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final CustomerNameContainsKeywordsPredicate predicate;
 
-    public FindCustomerCommand(NameContainsKeywordsPredicate predicate) {
+    public FindCustomerCommand(CustomerNameContainsKeywordsPredicate predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/loyaltylift/logic/commands/FindOrderCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/FindOrderCommand.java
@@ -1,0 +1,42 @@
+package seedu.loyaltylift.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.loyaltylift.commons.core.Messages;
+import seedu.loyaltylift.model.Model;
+import seedu.loyaltylift.model.order.OrderNameContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all orders in address book whose name contains any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
+public class FindOrderCommand extends Command {
+
+    public static final String COMMAND_WORD = "findo";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all orders whose names contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " alice bob charlie";
+
+    private final OrderNameContainsKeywordsPredicate predicate;
+
+    public FindOrderCommand(OrderNameContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredOrderList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_ORDERS_LISTED_OVERVIEW, model.getFilteredOrderList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindOrderCommand // instanceof handles nulls
+                && predicate.equals(((FindOrderCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/loyaltylift/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import seedu.loyaltylift.logic.commands.EditCustomerCommand;
 import seedu.loyaltylift.logic.commands.EditOrderCommand;
 import seedu.loyaltylift.logic.commands.ExitCommand;
 import seedu.loyaltylift.logic.commands.FindCustomerCommand;
+import seedu.loyaltylift.logic.commands.FindOrderCommand;
 import seedu.loyaltylift.logic.commands.HelpCommand;
 import seedu.loyaltylift.logic.commands.ListCustomerCommand;
 import seedu.loyaltylift.logic.commands.MarkCustomerCommand;
@@ -115,6 +116,9 @@ public class AddressBookParser {
 
         case AppendOrderNoteCommand.COMMAND_WORD:
             return new AppendOrderNoteCommandParser().parse(arguments);
+
+        case FindOrderCommand.COMMAND_WORD:
+            return new FindOrderCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/loyaltylift/logic/parser/FindCustomerCommandParser.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/FindCustomerCommandParser.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 
 import seedu.loyaltylift.logic.commands.FindCustomerCommand;
 import seedu.loyaltylift.logic.parser.exceptions.ParseException;
-import seedu.loyaltylift.model.customer.NameContainsKeywordsPredicate;
+import seedu.loyaltylift.model.customer.CustomerNameContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCustomerCommand object
@@ -27,7 +27,7 @@ public class FindCustomerCommandParser implements Parser<FindCustomerCommand> {
 
         String[] nameKeywords = trimmedArgs.split("\\s+");
 
-        return new FindCustomerCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        return new FindCustomerCommand(new CustomerNameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
     }
 
 }

--- a/src/main/java/seedu/loyaltylift/logic/parser/FindOrderCommandParser.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/FindOrderCommandParser.java
@@ -1,0 +1,33 @@
+package seedu.loyaltylift.logic.parser;
+
+import static seedu.loyaltylift.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.loyaltylift.logic.commands.FindOrderCommand;
+import seedu.loyaltylift.logic.parser.exceptions.ParseException;
+import seedu.loyaltylift.model.order.OrderNameContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FindOrderCommand object
+ */
+public class FindOrderCommandParser implements Parser<FindOrderCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindOrderCommand
+     * and returns a FindOrderCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindOrderCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindOrderCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new FindOrderCommand(new OrderNameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/loyaltylift/model/customer/CustomerNameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/loyaltylift/model/customer/CustomerNameContainsKeywordsPredicate.java
@@ -8,10 +8,10 @@ import seedu.loyaltylift.commons.util.StringUtil;
 /**
  * Tests that a {@code Customer}'s {@code Name} matches any of the keywords given.
  */
-public class NameContainsKeywordsPredicate implements Predicate<Customer> {
+public class CustomerNameContainsKeywordsPredicate implements Predicate<Customer> {
     private final List<String> keywords;
 
-    public NameContainsKeywordsPredicate(List<String> keywords) {
+    public CustomerNameContainsKeywordsPredicate(List<String> keywords) {
         this.keywords = keywords;
     }
 
@@ -24,8 +24,8 @@ public class NameContainsKeywordsPredicate implements Predicate<Customer> {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof NameContainsKeywordsPredicate // instanceof handles nulls
-                && keywords.equals(((NameContainsKeywordsPredicate) other).keywords)); // state check
+                || (other instanceof CustomerNameContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((CustomerNameContainsKeywordsPredicate) other).keywords)); // state check
     }
 
 }

--- a/src/main/java/seedu/loyaltylift/model/order/OrderNameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/loyaltylift/model/order/OrderNameContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.loyaltylift.model.order;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.loyaltylift.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Customer}'s {@code Name} matches any of the keywords given.
+ */
+public class OrderNameContainsKeywordsPredicate implements Predicate<Order> {
+    private final List<String> keywords;
+
+    public OrderNameContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Order customer) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(customer.getName().fullName, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof OrderNameContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((OrderNameContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/test/java/seedu/loyaltylift/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/CommandTestUtil.java
@@ -19,7 +19,7 @@ import seedu.loyaltylift.logic.commands.exceptions.CommandException;
 import seedu.loyaltylift.model.AddressBook;
 import seedu.loyaltylift.model.Model;
 import seedu.loyaltylift.model.customer.Customer;
-import seedu.loyaltylift.model.customer.NameContainsKeywordsPredicate;
+import seedu.loyaltylift.model.customer.CustomerNameContainsKeywordsPredicate;
 import seedu.loyaltylift.testutil.EditCustomerDescriptorBuilder;
 
 /**
@@ -153,7 +153,7 @@ public class CommandTestUtil {
 
         Customer customer = model.getFilteredCustomerList().get(targetIndex.getZeroBased());
         final String[] splitName = customer.getName().fullName.split("\\s+");
-        model.updateFilteredCustomerList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+        model.updateFilteredCustomerList(new CustomerNameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredCustomerList().size());
     }

--- a/src/test/java/seedu/loyaltylift/logic/commands/FindCustomerCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/FindCustomerCommandTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import seedu.loyaltylift.model.Model;
 import seedu.loyaltylift.model.ModelManager;
 import seedu.loyaltylift.model.UserPrefs;
-import seedu.loyaltylift.model.customer.NameContainsKeywordsPredicate;
+import seedu.loyaltylift.model.customer.CustomerNameContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCustomerCommand}.
@@ -29,10 +29,10 @@ public class FindCustomerCommandTest {
 
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+        CustomerNameContainsKeywordsPredicate firstPredicate =
+                new CustomerNameContainsKeywordsPredicate(Collections.singletonList("first"));
+        CustomerNameContainsKeywordsPredicate secondPredicate =
+                new CustomerNameContainsKeywordsPredicate(Collections.singletonList("second"));
 
         FindCustomerCommand findFirstCommand = new FindCustomerCommand(firstPredicate);
         FindCustomerCommand findSecondCommand = new FindCustomerCommand(secondPredicate);
@@ -57,7 +57,7 @@ public class FindCustomerCommandTest {
     @Test
     public void execute_zeroKeywords_noCustomerFound() {
         String expectedMessage = String.format(MESSAGE_CUSTOMERS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        CustomerNameContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCustomerCommand command = new FindCustomerCommand(predicate);
         expectedModel.updateFilteredCustomerList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -67,7 +67,7 @@ public class FindCustomerCommandTest {
     @Test
     public void execute_multipleKeywords_multipleCustomersFound() {
         String expectedMessage = String.format(MESSAGE_CUSTOMERS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        CustomerNameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCustomerCommand command = new FindCustomerCommand(predicate);
         expectedModel.updateFilteredCustomerList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -77,7 +77,7 @@ public class FindCustomerCommandTest {
     /**
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    private CustomerNameContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new CustomerNameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/loyaltylift/logic/commands/FindOrderCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/FindOrderCommandTest.java
@@ -1,0 +1,83 @@
+package seedu.loyaltylift.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.loyaltylift.commons.core.Messages.MESSAGE_ORDERS_LISTED_OVERVIEW;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.loyaltylift.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.loyaltylift.testutil.TypicalOrders.ORDER_A;
+import static seedu.loyaltylift.testutil.TypicalOrders.ORDER_C;
+import static seedu.loyaltylift.testutil.TypicalOrders.ORDER_D;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.loyaltylift.model.Model;
+import seedu.loyaltylift.model.ModelManager;
+import seedu.loyaltylift.model.UserPrefs;
+import seedu.loyaltylift.model.order.OrderNameContainsKeywordsPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FindOrderCommand}.
+ */
+public class FindOrderCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        OrderNameContainsKeywordsPredicate firstPredicate =
+                new OrderNameContainsKeywordsPredicate(Collections.singletonList("first"));
+        OrderNameContainsKeywordsPredicate secondPredicate =
+                new OrderNameContainsKeywordsPredicate(Collections.singletonList("second"));
+
+        FindOrderCommand findFirstCommand = new FindOrderCommand(firstPredicate);
+        FindOrderCommand findSecondCommand = new FindOrderCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(findFirstCommand.equals(findFirstCommand));
+
+        // same values -> returns true
+        FindOrderCommand findFirstCommandCopy = new FindOrderCommand(firstPredicate);
+        assertTrue(findFirstCommand.equals(findFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(findFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(findFirstCommand.equals(null));
+
+        // different order -> returns false
+        assertFalse(findFirstCommand.equals(findSecondCommand));
+    }
+
+    @Test
+    public void execute_zeroKeywords_noOrderFound() {
+        String expectedMessage = String.format(MESSAGE_ORDERS_LISTED_OVERVIEW, 0);
+        OrderNameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        FindOrderCommand command = new FindOrderCommand(predicate);
+        expectedModel.updateFilteredOrderList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredOrderList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_multipleOrdersFound() {
+        String expectedMessage = String.format(MESSAGE_ORDERS_LISTED_OVERVIEW, 3);
+        OrderNameContainsKeywordsPredicate predicate = preparePredicate("Strawberry Melon");
+        FindOrderCommand command = new FindOrderCommand(predicate);
+        expectedModel.updateFilteredOrderList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ORDER_A, ORDER_C, ORDER_D), model.getFilteredOrderList());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     */
+    private OrderNameContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new OrderNameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+}

--- a/src/test/java/seedu/loyaltylift/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/AddressBookParserTest.java
@@ -25,6 +25,7 @@ import seedu.loyaltylift.logic.commands.EditCustomerCommand;
 import seedu.loyaltylift.logic.commands.EditCustomerCommand.EditCustomerDescriptor;
 import seedu.loyaltylift.logic.commands.ExitCommand;
 import seedu.loyaltylift.logic.commands.FindCustomerCommand;
+import seedu.loyaltylift.logic.commands.FindOrderCommand;
 import seedu.loyaltylift.logic.commands.HelpCommand;
 import seedu.loyaltylift.logic.commands.ListCustomerCommand;
 import seedu.loyaltylift.logic.commands.SetCustomerNoteCommand;
@@ -36,6 +37,7 @@ import seedu.loyaltylift.model.attribute.Note;
 import seedu.loyaltylift.model.customer.Customer;
 import seedu.loyaltylift.model.customer.CustomerNameContainsKeywordsPredicate;
 import seedu.loyaltylift.model.customer.Points;
+import seedu.loyaltylift.model.order.OrderNameContainsKeywordsPredicate;
 import seedu.loyaltylift.testutil.CustomerBuilder;
 import seedu.loyaltylift.testutil.CustomerUtil;
 import seedu.loyaltylift.testutil.EditCustomerDescriptorBuilder;
@@ -160,6 +162,14 @@ public class AddressBookParserTest {
                 + INDEX_FIRST.getOneBased() + " "
                 + PREFIX_NOTE + noteToAppend);
         assertEquals(new AppendOrderNoteCommand(INDEX_FIRST, noteToAppend), command);
+    }
+
+    @Test
+    public void parseCommand_findo() throws Exception {
+        List<String> keywords = Arrays.asList("foo", "bar", "baz");
+        FindOrderCommand command = (FindOrderCommand) parser.parseCommand(
+                FindOrderCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindOrderCommand(new OrderNameContainsKeywordsPredicate(keywords)), command);
     }
 
     @Test

--- a/src/test/java/seedu/loyaltylift/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/AddressBookParserTest.java
@@ -34,7 +34,7 @@ import seedu.loyaltylift.logic.commands.ViewCustomerCommand;
 import seedu.loyaltylift.logic.parser.exceptions.ParseException;
 import seedu.loyaltylift.model.attribute.Note;
 import seedu.loyaltylift.model.customer.Customer;
-import seedu.loyaltylift.model.customer.NameContainsKeywordsPredicate;
+import seedu.loyaltylift.model.customer.CustomerNameContainsKeywordsPredicate;
 import seedu.loyaltylift.model.customer.Points;
 import seedu.loyaltylift.testutil.CustomerBuilder;
 import seedu.loyaltylift.testutil.CustomerUtil;
@@ -85,7 +85,7 @@ public class AddressBookParserTest {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCustomerCommand command = (FindCustomerCommand) parser.parseCommand(
                 FindCustomerCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCustomerCommand(new NameContainsKeywordsPredicate(keywords)), command);
+        assertEquals(new FindCustomerCommand(new CustomerNameContainsKeywordsPredicate(keywords)), command);
     }
 
     @Test

--- a/src/test/java/seedu/loyaltylift/logic/parser/FindCustomerCommandParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/FindCustomerCommandParserTest.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.loyaltylift.logic.commands.FindCustomerCommand;
-import seedu.loyaltylift.model.customer.NameContainsKeywordsPredicate;
+import seedu.loyaltylift.model.customer.CustomerNameContainsKeywordsPredicate;
 
 public class FindCustomerCommandParserTest {
 
@@ -27,7 +27,7 @@ public class FindCustomerCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCustomerCommand expectedFindCustomerCommand =
-                new FindCustomerCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+                new FindCustomerCommand(new CustomerNameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
         assertParseSuccess(parser, "Alice Bob", expectedFindCustomerCommand);
 
         // multiple whitespaces between keywords

--- a/src/test/java/seedu/loyaltylift/logic/parser/FindOrderCommandParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/FindOrderCommandParserTest.java
@@ -1,0 +1,37 @@
+package seedu.loyaltylift.logic.parser;
+
+import static seedu.loyaltylift.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.loyaltylift.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.loyaltylift.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.loyaltylift.logic.commands.FindOrderCommand;
+import seedu.loyaltylift.model.order.OrderNameContainsKeywordsPredicate;
+
+public class FindOrderCommandParserTest {
+
+    private FindOrderCommandParser parser = new FindOrderCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(
+                parser,
+                "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindOrderCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces
+        FindOrderCommand expectedFindOrderCommand =
+                new FindOrderCommand(new OrderNameContainsKeywordsPredicate(Arrays.asList("Strawberry", "Shortcake")));
+        assertParseSuccess(parser, "Strawberry Shortcake", expectedFindOrderCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n Strawberry \n \t Shortcake  \t", expectedFindOrderCommand);
+    }
+
+}

--- a/src/test/java/seedu/loyaltylift/model/ModelManagerTest.java
+++ b/src/test/java/seedu/loyaltylift/model/ModelManagerTest.java
@@ -16,7 +16,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.loyaltylift.commons.core.GuiSettings;
-import seedu.loyaltylift.model.customer.NameContainsKeywordsPredicate;
+import seedu.loyaltylift.model.customer.CustomerNameContainsKeywordsPredicate;
 import seedu.loyaltylift.testutil.AddressBookBuilder;
 
 public class ModelManagerTest {
@@ -146,7 +146,7 @@ public class ModelManagerTest {
 
         // different filteredList -> returns false
         String[] keywords = ALICE.getName().fullName.split("\\s+");
-        modelManager.updateFilteredCustomerList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
+        modelManager.updateFilteredCustomerList(new CustomerNameContainsKeywordsPredicate(Arrays.asList(keywords)));
         assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
 
         // resets modelManager to initial state for upcoming tests

--- a/src/test/java/seedu/loyaltylift/model/customer/CustomerNameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/loyaltylift/model/customer/CustomerNameContainsKeywordsPredicateTest.java
@@ -11,21 +11,24 @@ import org.junit.jupiter.api.Test;
 
 import seedu.loyaltylift.testutil.CustomerBuilder;
 
-public class NameContainsKeywordsPredicateTest {
+public class CustomerNameContainsKeywordsPredicateTest {
 
     @Test
     public void equals() {
         List<String> firstPredicateKeywordList = Collections.singletonList("first");
         List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
 
-        NameContainsKeywordsPredicate firstPredicate = new NameContainsKeywordsPredicate(firstPredicateKeywordList);
-        NameContainsKeywordsPredicate secondPredicate = new NameContainsKeywordsPredicate(secondPredicateKeywordList);
+        CustomerNameContainsKeywordsPredicate firstPredicate = new CustomerNameContainsKeywordsPredicate(
+                firstPredicateKeywordList);
+        CustomerNameContainsKeywordsPredicate secondPredicate = new CustomerNameContainsKeywordsPredicate(
+                secondPredicateKeywordList);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        NameContainsKeywordsPredicate firstPredicateCopy = new NameContainsKeywordsPredicate(firstPredicateKeywordList);
+        CustomerNameContainsKeywordsPredicate firstPredicateCopy = new CustomerNameContainsKeywordsPredicate(
+                firstPredicateKeywordList);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -41,34 +44,37 @@ public class NameContainsKeywordsPredicateTest {
     @Test
     public void test_nameContainsKeywords_returnsTrue() {
         // One keyword
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.singletonList("Alice"));
+        CustomerNameContainsKeywordsPredicate predicate = new CustomerNameContainsKeywordsPredicate(
+                Collections.singletonList("Alice"));
         assertTrue(predicate.test(new CustomerBuilder().withName("Alice Bob").build()));
 
         // Multiple keywords
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
+        predicate = new CustomerNameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
         assertTrue(predicate.test(new CustomerBuilder().withName("Alice Bob").build()));
 
         // Only one matching keyword
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
+        predicate = new CustomerNameContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
         assertTrue(predicate.test(new CustomerBuilder().withName("Alice Carol").build()));
 
         // Mixed-case keywords
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("aLIce", "bOB"));
+        predicate = new CustomerNameContainsKeywordsPredicate(Arrays.asList("aLIce", "bOB"));
         assertTrue(predicate.test(new CustomerBuilder().withName("Alice Bob").build()));
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
         // Zero keywords
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.emptyList());
+        CustomerNameContainsKeywordsPredicate predicate = new CustomerNameContainsKeywordsPredicate(
+                Collections.emptyList());
         assertFalse(predicate.test(new CustomerBuilder().withName("Alice").build()));
 
         // Non-matching keyword
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Carol"));
+        predicate = new CustomerNameContainsKeywordsPredicate(Arrays.asList("Carol"));
         assertFalse(predicate.test(new CustomerBuilder().withName("Alice Bob").build()));
 
         // Keywords match phone, email and address, but does not match name
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
+        predicate = new CustomerNameContainsKeywordsPredicate(
+                Arrays.asList("12345", "alice@email.com", "Main", "Street"));
         assertFalse(predicate.test(new CustomerBuilder().withName("Alice").withPhone("12345")
                 .withEmail("alice@email.com").withAddress("Main Street").build()));
     }

--- a/src/test/java/seedu/loyaltylift/model/order/OrderNameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/loyaltylift/model/order/OrderNameContainsKeywordsPredicateTest.java
@@ -1,0 +1,80 @@
+package seedu.loyaltylift.model.order;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.loyaltylift.testutil.OrderBuilder;
+
+public class OrderNameContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        OrderNameContainsKeywordsPredicate firstPredicate = new OrderNameContainsKeywordsPredicate(
+                firstPredicateKeywordList);
+        OrderNameContainsKeywordsPredicate secondPredicate = new OrderNameContainsKeywordsPredicate(
+                secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        OrderNameContainsKeywordsPredicate firstPredicateCopy = new OrderNameContainsKeywordsPredicate(
+                firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different order -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_nameContainsKeywords_returnsTrue() {
+        // One keyword
+        OrderNameContainsKeywordsPredicate predicate = new OrderNameContainsKeywordsPredicate(
+                Collections.singletonList("Strawberry"));
+        assertTrue(predicate.test(new OrderBuilder().withName("Strawberry Shortcake").build()));
+
+        // Multiple keywords
+        predicate = new OrderNameContainsKeywordsPredicate(Arrays.asList("Strawberry", "Shortcake"));
+        assertTrue(predicate.test(new OrderBuilder().withName("Strawberry Shortcake").build()));
+
+        // Only one matching keyword
+        predicate = new OrderNameContainsKeywordsPredicate(Arrays.asList("Strawberry", "Melon"));
+        assertTrue(predicate.test(new OrderBuilder().withName("Strawberry Shortcake").build()));
+
+        // Mixed-case keywords
+        predicate = new OrderNameContainsKeywordsPredicate(Arrays.asList("stRAwBerRy", "ShOrTcakE"));
+        assertTrue(predicate.test(new OrderBuilder().withName("Strawberry Shortcake").build()));
+    }
+
+    @Test
+    public void test_nameDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        OrderNameContainsKeywordsPredicate predicate = new OrderNameContainsKeywordsPredicate(
+                Collections.emptyList());
+        assertFalse(predicate.test(new OrderBuilder().withName("Strawberry Shortcake").build()));
+
+        // Non-matching keyword
+        predicate = new OrderNameContainsKeywordsPredicate(Arrays.asList("Melon"));
+        assertFalse(predicate.test(new OrderBuilder().withName("Strawberry Shortcake").build()));
+
+        // Keywords match address, but does not match name
+        predicate = new OrderNameContainsKeywordsPredicate(Arrays.asList("Main", "Street"));
+        assertFalse(predicate.test(new OrderBuilder().withName("Strawberry Shortcake")
+                .withAddress("Main Street").build()));
+    }
+}


### PR DESCRIPTION
Includes the `findo` command -- pretty much a copy of `findc` but for orders.

This implementation involves:

- Renaming `NameContainsKeywordsPredicate` class in `Customer` to `CustomerNameContainsKeywordsPredicate`
- Creating an `OrderNameContainsKeywordsPredicate` class in `Order`

Closes #63