### PR TITLE
Sort customer points

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -187,7 +187,18 @@ We settled on just a **set** and **append** command as deleting a note can be do
 
   This could be done inline using a special character (e.g. `#`) within the note itself, where the system would automatically detect the tags.
 
-  We can then provide an additional command to view all the notes with a specific tag, along with their associated customer/order.  
+  We can then provide an additional command to view all the notes with a specific tag, along with their associated customer/order.
+
+### Sorting feature
+
+Customers can be sorted either by name or by points. We decided to implement the sorting as a parameter for the `listc` command.
+
+The sorting is done by adding a JavaFX `SortedList` to the `Model`, with the original `FilteredList` as its source. This `SortedList` is then used to display the customer list in place of the `FilteredList`.
+
+The `SortedList` can be sorted by a `Comparator`.
+
+* The `Comparator`s for each sorting option is provided as static constants by the `Customer` class.
+* To facilitate the comparators, the relevant attribute classes (i.e. `Name` and `Points`) will also implement the `Comparable` interface.
 
 ### \[Proposed\] Undo/redo feature
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -92,7 +92,14 @@ Examples:
 
 Shows a list of all customers.
 
-Format: `listc`
+Format: `listc [s/{name|points}]`
+
+* Lists all customer with the specified sorting option.
+* Be default, customers are sorted by name
+
+Examples:
+* `listc` lists all customers sorted by name
+* `listc s/points` lists all customers sorted by points
 
 ### Deleting a customer : `deletec`
 

--- a/src/main/java/seedu/loyaltylift/logic/commands/FindCustomerCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/FindCustomerCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.loyaltylift.commons.core.Messages;
 import seedu.loyaltylift.model.Model;
+import seedu.loyaltylift.model.customer.Customer;
 import seedu.loyaltylift.model.customer.CustomerNameContainsKeywordsPredicate;
 
 /**
@@ -28,6 +29,7 @@ public class FindCustomerCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+        model.sortFilteredCustomerList(Customer.SORT_NAME);
         model.updateFilteredCustomerList(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_CUSTOMERS_LISTED_OVERVIEW, model.getFilteredCustomerList().size()));

--- a/src/main/java/seedu/loyaltylift/logic/commands/ListCustomerCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/ListCustomerCommand.java
@@ -1,9 +1,13 @@
 package seedu.loyaltylift.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_SORT;
 import static seedu.loyaltylift.model.Model.PREDICATE_SHOW_ALL_CUSTOMERS;
 
+import java.util.Comparator;
+
 import seedu.loyaltylift.model.Model;
+import seedu.loyaltylift.model.customer.Customer;
 
 /**
  * Lists all customers in the address book to the user.
@@ -12,13 +16,32 @@ public class ListCustomerCommand extends Command {
 
     public static final String COMMAND_WORD = "listc";
 
-    public static final String MESSAGE_SUCCESS = "Listed all customers";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all customers with an optional sort option "
+            + "(name by default) and displays them as a list with index numbers.\n"
+            + "Parameters: [" + PREFIX_SORT + "{name|points}]\n"
+            + "Example: " + COMMAND_WORD + " s/points";
 
+    public static final String MESSAGE_SUCCESS = "Listed all customers";
+    public static final String MESSAGE_INVALID_SORT = "Unrecognized sort option";
+
+    private final Comparator<Customer> comparator;
+
+    public ListCustomerCommand(Comparator<Customer> comparator) {
+        this.comparator = comparator;
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+        model.sortFilteredCustomerList(comparator);
         model.updateFilteredCustomerList(PREDICATE_SHOW_ALL_CUSTOMERS);
         return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ListCustomerCommand // instanceof handles nulls
+                && comparator.equals(((ListCustomerCommand) other).comparator)); // state check
     }
 }

--- a/src/main/java/seedu/loyaltylift/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/AddressBookParser.java
@@ -73,7 +73,7 @@ public class AddressBookParser {
             return new FindCustomerCommandParser().parse(arguments);
 
         case ListCustomerCommand.COMMAND_WORD:
-            return new ListCustomerCommand();
+            return new ListCustomerCommandParser().parse(arguments);
 
         case MarkCustomerCommand.COMMAND_WORD:
             return new MarkCustomerCommandParser().parse(arguments);

--- a/src/main/java/seedu/loyaltylift/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/CliSyntax.java
@@ -15,5 +15,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_QUANTITY = new Prefix("q/");
     public static final Prefix PREFIX_POINTS = new Prefix("pt/");
     public static final Prefix PREFIX_NOTE = new Prefix("nt/");
+    public static final Prefix PREFIX_SORT = new Prefix("s/");
 
 }

--- a/src/main/java/seedu/loyaltylift/logic/parser/ListCustomerCommandParser.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/ListCustomerCommandParser.java
@@ -1,0 +1,43 @@
+package seedu.loyaltylift.logic.parser;
+
+import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_SORT;
+
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+import seedu.loyaltylift.logic.commands.ListCustomerCommand;
+import seedu.loyaltylift.logic.parser.exceptions.ParseException;
+import seedu.loyaltylift.model.customer.Customer;
+
+/**
+ * Parses input arguments and creates a new FindCustomerCommand object
+ */
+public class ListCustomerCommandParser implements Parser<ListCustomerCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ListCustomerCommand
+     * and returns a ListCustomerCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ListCustomerCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_SORT);
+
+        Comparator<Customer> comparator;
+        if (!arePrefixesPresent(argMultimap, PREFIX_SORT)) {
+            comparator = Customer.SORT_NAME;
+        } else {
+            comparator = ParserUtil.parseSortOption(argMultimap.getValue(PREFIX_SORT).orElse(""));
+        }
+
+        return new ListCustomerCommand(comparator);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/loyaltylift/logic/parser/ListCustomerCommandParser.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/ListCustomerCommandParser.java
@@ -10,7 +10,7 @@ import seedu.loyaltylift.logic.parser.exceptions.ParseException;
 import seedu.loyaltylift.model.customer.Customer;
 
 /**
- * Parses input arguments and creates a new FindCustomerCommand object
+ * Parses input arguments and creates a new ListCustomerCommand object
  */
 public class ListCustomerCommandParser implements Parser<ListCustomerCommand> {
 
@@ -22,10 +22,8 @@ public class ListCustomerCommandParser implements Parser<ListCustomerCommand> {
     public ListCustomerCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_SORT);
 
-        Comparator<Customer> comparator;
-        if (!arePrefixesPresent(argMultimap, PREFIX_SORT)) {
-            comparator = Customer.SORT_NAME;
-        } else {
+        Comparator<Customer> comparator = Customer.SORT_NAME;
+        if (arePrefixesPresent(argMultimap, PREFIX_SORT)) {
             comparator = ParserUtil.parseSortOption(argMultimap.getValue(PREFIX_SORT).orElse(""));
         }
 

--- a/src/main/java/seedu/loyaltylift/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/ParserUtil.java
@@ -3,15 +3,18 @@ package seedu.loyaltylift.logic.parser;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
 
 import seedu.loyaltylift.commons.core.index.Index;
 import seedu.loyaltylift.commons.util.StringUtil;
+import seedu.loyaltylift.logic.commands.ListCustomerCommand;
 import seedu.loyaltylift.logic.parser.exceptions.ParseException;
 import seedu.loyaltylift.model.attribute.Address;
 import seedu.loyaltylift.model.attribute.Name;
 import seedu.loyaltylift.model.attribute.Note;
+import seedu.loyaltylift.model.customer.Customer;
 import seedu.loyaltylift.model.customer.CustomerType;
 import seedu.loyaltylift.model.customer.Email;
 import seedu.loyaltylift.model.customer.Phone;
@@ -220,5 +223,22 @@ public class ParserUtil {
         requireNonNull(note);
         String trimmedNote = note.trim();
         return new Note(trimmedNote);
+    }
+
+    /**
+     * Parses a {@code String sortOption} into a {@code Comparator<T>}.
+     * @throws ParseException if the given {@code attribute} is invalid.
+     */
+    public static Comparator<Customer> parseSortOption(String sortOption) throws ParseException {
+        requireNonNull(sortOption);
+        String trimmedAttribute = sortOption.trim();
+        switch (trimmedAttribute) {
+        case "name":
+            return Customer.SORT_NAME;
+        case "points":
+            return Customer.SORT_POINTS;
+        default:
+            throw new ParseException(ListCustomerCommand.MESSAGE_INVALID_SORT);
+        }
     }
 }

--- a/src/main/java/seedu/loyaltylift/model/Model.java
+++ b/src/main/java/seedu/loyaltylift/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.loyaltylift.model;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -87,6 +88,12 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredCustomerList(Predicate<Customer> predicate);
+
+    /**
+     * Sorts the filtered customer list using the given {@code comparator}.
+     * @throws NullPointerException if {@code comparator} is null.
+     */
+    void sortFilteredCustomerList(Comparator<Customer> comparator);
 
     /**
      * Returns true if a order with the same identity as {@code order} exists in the address book.

--- a/src/main/java/seedu/loyaltylift/model/ModelManager.java
+++ b/src/main/java/seedu/loyaltylift/model/ModelManager.java
@@ -42,7 +42,7 @@ public class ModelManager implements Model {
         filteredCustomers = new FilteredList<>(this.addressBook.getCustomerList());
         filteredOrders = new FilteredList<>(this.addressBook.getOrderList());
         filteredCustomerOrders = new FilteredList<>(this.addressBook.getOrderList());
-        sortedCustomers = new SortedList<>(filteredCustomers);
+        sortedCustomers = new SortedList<>(filteredCustomers, Customer.SORT_NAME);
     }
 
     public ModelManager() {

--- a/src/main/java/seedu/loyaltylift/model/ModelManager.java
+++ b/src/main/java/seedu/loyaltylift/model/ModelManager.java
@@ -4,11 +4,13 @@ import static java.util.Objects.requireNonNull;
 import static seedu.loyaltylift.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
 import seedu.loyaltylift.commons.core.GuiSettings;
 import seedu.loyaltylift.commons.core.LogsCenter;
 import seedu.loyaltylift.model.customer.Customer;
@@ -23,6 +25,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Customer> filteredCustomers;
+    private final SortedList<Customer> sortedCustomers;
     private final FilteredList<Order> filteredOrders;
     private final FilteredList<Order> filteredCustomerOrders;
 
@@ -39,6 +42,7 @@ public class ModelManager implements Model {
         filteredCustomers = new FilteredList<>(this.addressBook.getCustomerList());
         filteredOrders = new FilteredList<>(this.addressBook.getOrderList());
         filteredCustomerOrders = new FilteredList<>(this.addressBook.getOrderList());
+        sortedCustomers = new SortedList<>(filteredCustomers);
     }
 
     public ModelManager() {
@@ -152,13 +156,18 @@ public class ModelManager implements Model {
      */
     @Override
     public ObservableList<Customer> getFilteredCustomerList() {
-        return filteredCustomers;
+        return sortedCustomers;
     }
 
     @Override
     public void updateFilteredCustomerList(Predicate<Customer> predicate) {
         requireNonNull(predicate);
         filteredCustomers.setPredicate(predicate);
+    }
+
+    @Override
+    public void sortFilteredCustomerList(Comparator<Customer> comparator) {
+        sortedCustomers.setComparator(comparator);
     }
 
     //=========== Filtered Order List Accessors ==============================================================

--- a/src/main/java/seedu/loyaltylift/model/attribute/Name.java
+++ b/src/main/java/seedu/loyaltylift/model/attribute/Name.java
@@ -7,7 +7,7 @@ import static seedu.loyaltylift.commons.util.AppUtil.checkArgument;
  * Represents a Customer's name in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
  */
-public class Name {
+public class Name implements Comparable<Name> {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
@@ -54,6 +54,11 @@ public class Name {
     @Override
     public int hashCode() {
         return fullName.hashCode();
+    }
+
+    @Override
+    public int compareTo(Name o) {
+        return fullName.compareTo(o.fullName);
     }
 
 }

--- a/src/main/java/seedu/loyaltylift/model/customer/Customer.java
+++ b/src/main/java/seedu/loyaltylift/model/customer/Customer.java
@@ -20,8 +20,8 @@ import seedu.loyaltylift.model.tag.Tag;
 public class Customer {
 
     // Comparators
-    public static final Comparator<Customer> SORT_NAME = Comparator.comparing(c -> c.name.fullName);
-    public static final Comparator<Customer> SORT_POINTS = Comparator.comparingInt((Customer c) -> c.points.value)
+    public static final Comparator<Customer> SORT_NAME = Comparator.comparing(Customer::getName);
+    public static final Comparator<Customer> SORT_POINTS = Comparator.comparing(Customer::getPoints)
             .reversed().thenComparing(SORT_NAME);
 
     // Identity fields

--- a/src/main/java/seedu/loyaltylift/model/customer/Customer.java
+++ b/src/main/java/seedu/loyaltylift/model/customer/Customer.java
@@ -3,6 +3,7 @@ package seedu.loyaltylift.model.customer;
 import static seedu.loyaltylift.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -17,6 +18,9 @@ import seedu.loyaltylift.model.tag.Tag;
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class Customer {
+
+    // Comparators
+    public static final Comparator<Customer> SORT_NAME = (a, b) -> a.name.fullName.compareTo(b.name.fullName);
 
     // Identity fields
     private final Name name;

--- a/src/main/java/seedu/loyaltylift/model/customer/Customer.java
+++ b/src/main/java/seedu/loyaltylift/model/customer/Customer.java
@@ -20,7 +20,9 @@ import seedu.loyaltylift.model.tag.Tag;
 public class Customer {
 
     // Comparators
-    public static final Comparator<Customer> SORT_NAME = (a, b) -> a.name.fullName.compareTo(b.name.fullName);
+    public static final Comparator<Customer> SORT_NAME = Comparator.comparing(c -> c.name.fullName);
+    public static final Comparator<Customer> SORT_POINTS = Comparator.comparingInt((Customer c) -> c.points.value)
+            .reversed().thenComparing(SORT_NAME);
 
     // Identity fields
     private final Name name;

--- a/src/main/java/seedu/loyaltylift/model/customer/Points.java
+++ b/src/main/java/seedu/loyaltylift/model/customer/Points.java
@@ -8,7 +8,7 @@ import seedu.loyaltylift.commons.exceptions.IllegalValueException;
  * Represents a Customer's points in the address book.
  * The minimum points a customer can have is 0.
  */
-public class Points {
+public class Points implements Comparable<Points> {
     public static final Integer MAXIMUM_POINTS = 999999;
     public static final Integer MINIMUM_POINTS = 0;
 
@@ -107,5 +107,11 @@ public class Points {
     @Override
     public int hashCode() {
         return value.hashCode();
+    }
+
+    @Override
+    public int compareTo(Points o) {
+        int i = value.compareTo(o.value);
+        return (i != 0) ? i : cumulative.compareTo(o.cumulative);
     }
 }

--- a/src/test/java/seedu/loyaltylift/logic/commands/AddCustomerCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/AddCustomerCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.loyaltylift.testutil.Assert.assertThrows;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -153,6 +154,11 @@ public class AddCustomerCommandTest {
 
         @Override
         public void updateFilteredCustomerList(Predicate<Customer> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void sortFilteredCustomerList(Comparator<Customer> comparator) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/loyaltylift/logic/commands/ListCustomerCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/ListCustomerCommandTest.java
@@ -1,5 +1,7 @@
 package seedu.loyaltylift.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.loyaltylift.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.loyaltylift.logic.commands.CommandTestUtil.showCustomerAtIndex;
 import static seedu.loyaltylift.testutil.TypicalAddressBook.getTypicalAddressBook;
@@ -11,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import seedu.loyaltylift.model.Model;
 import seedu.loyaltylift.model.ModelManager;
 import seedu.loyaltylift.model.UserPrefs;
+import seedu.loyaltylift.model.customer.Customer;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCustomerCommand.
@@ -27,13 +30,35 @@ public class ListCustomerCommandTest {
     }
 
     @Test
+    public void equals() {
+        ListCustomerCommand listSortNameCommand = new ListCustomerCommand(Customer.SORT_NAME);
+        ListCustomerCommand listSortOrderCommand = new ListCustomerCommand(Customer.SORT_POINTS);
+
+        // same object -> returns true
+        assertTrue(listSortNameCommand.equals(listSortNameCommand));
+
+        // same comparator -> returns true
+        ListCustomerCommand listSortNameCommandCopy = new ListCustomerCommand(Customer.SORT_NAME);
+        assertTrue(listSortNameCommand.equals(listSortNameCommandCopy));
+
+        // different types -> returns false
+        assertFalse(listSortNameCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(listSortNameCommand.equals(null));
+
+        // different comparator -> returns false
+        assertFalse(listSortNameCommand.equals(listSortOrderCommand));
+    }
+
+    @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCustomerCommand(), model, ListCustomerCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCustomerCommand(null), model, ListCustomerCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showCustomerAtIndex(model, INDEX_FIRST);
-        assertCommandSuccess(new ListCustomerCommand(), model, ListCustomerCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCustomerCommand(null), model, ListCustomerCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/loyaltylift/logic/parser/ListCustomerCommandParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/ListCustomerCommandParserTest.java
@@ -1,0 +1,29 @@
+package seedu.loyaltylift.logic.parser;
+
+import static seedu.loyaltylift.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.loyaltylift.logic.commands.ListCustomerCommand;
+import seedu.loyaltylift.model.customer.Customer;
+
+public class ListCustomerCommandParserTest {
+
+    private ListCustomerCommandParser parser = new ListCustomerCommandParser();
+
+    @Test
+    public void parse_emptyArgs_returnsListCommand() {
+        // sort by name
+        ListCustomerCommand expectedListCustomerCommand =
+                new ListCustomerCommand(Customer.SORT_NAME);
+        assertParseSuccess(parser, "    ", expectedListCustomerCommand);
+    }
+
+    @Test
+    public void parse_validSortOption_returnsListCommand() {
+        ListCustomerCommand expectedListSortNameCustomerCommand =
+                new ListCustomerCommand(Customer.SORT_NAME);
+        assertParseSuccess(parser, "s/name", expectedListSortNameCustomerCommand);
+    }
+
+}

--- a/src/test/java/seedu/loyaltylift/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/ParserUtilTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import seedu.loyaltylift.logic.parser.exceptions.ParseException;
 import seedu.loyaltylift.model.attribute.Address;
 import seedu.loyaltylift.model.attribute.Name;
+import seedu.loyaltylift.model.customer.Customer;
 import seedu.loyaltylift.model.customer.CustomerType;
 import seedu.loyaltylift.model.customer.Email;
 import seedu.loyaltylift.model.customer.Phone;
@@ -28,6 +29,7 @@ public class ParserUtilTest {
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
     private static final String INVALID_CUSTOMER_TYPE = "person";
+    private static final String INVALID_SORT_OPTION = "invalid";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
@@ -37,6 +39,8 @@ public class ParserUtilTest {
     private static final String VALID_TAG_2 = "neighbour";
     private static final String VALID_CUSTOMER_TYPE_IND = "ind";
     private static final String VALID_CUSTOMER_TYPE_ENT = "ent";
+    private static final String VALID_SORT_OPTION_NAME = "name";
+    private static final String VALID_SORT_OPTION_POINTS = "points";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -213,5 +217,21 @@ public class ParserUtilTest {
     @Test
     public void parseCustomerType_invalidCustomerType_throwsParseException() throws Exception {
         assertThrows(ParseException.class, () -> ParserUtil.parseCustomerType(INVALID_CUSTOMER_TYPE));
+    }
+
+    @Test
+    public void parseSortOption_validSortOption() throws Exception {
+        assertEquals(ParserUtil.parseSortOption(VALID_SORT_OPTION_NAME), Customer.SORT_NAME);
+        assertEquals(ParserUtil.parseSortOption(VALID_SORT_OPTION_POINTS), Customer.SORT_POINTS);
+    }
+
+    @Test
+    public void parseSortOption_null_throwsNullPointerException() throws Exception {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseSortOption(null));
+    }
+
+    @Test
+    public void parseSortOption_invalidSortOption_throwsParseException() throws Exception {
+        assertThrows(ParseException.class, () -> ParserUtil.parseSortOption(INVALID_SORT_OPTION));
     }
 }


### PR DESCRIPTION
Updates the `listc` command to accept a sorting option as a parameter:

`listc [s/{name|points}]`

Notable changes:

* Customers are now sorted by name by default
* `Name` and `Points` now implement `Comparable`
* Added a `SortedList<Customer>` to the the model
* The UI now uses the `SortedList` to display the customer list
* The comparators to sort the `SortedList` are provided in the `Customer` class

Closes #62