### PR TITLE
Sort order status

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -232,14 +232,14 @@ We settled on just a **set** and **append** command as deleting a note can be do
 
 ### Sorting feature
 
-Customers can be sorted either by name or by points. We decided to implement the sorting as a parameter for the `listc` command.
+Customers and Orders can be sorted by certain attributes. We decided to implement the sorting as a parameter for the list commands.
 
-The sorting is done by adding a JavaFX `SortedList` to the `Model`, with the original `FilteredList` as its source. This `SortedList` is then used to display the customer list in place of the `FilteredList`.
+The sorting is done by adding a JavaFX `SortedList` to the `Model`, with the original `FilteredList` as its source. This `SortedList` is then used to display the customer and order list in place of the `FilteredList`.
 
 The `SortedList` can be sorted by a `Comparator`.
 
-* The `Comparator`s for each sorting option is provided as static constants by the `Customer` class.
-* To facilitate the comparators, the relevant attribute classes (i.e. `Name` and `Points`) will also implement the `Comparable` interface.
+* The `Comparator`s for each sorting option is provided as static constants by the `Customer` and `Order` class.
+* To facilitate the comparators, the relevant attribute classes (e.g. `Name` and `Points`) will also implement the `Comparable` interface.
 
 
 ### Order Status

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -309,17 +309,18 @@ Examples:
 
 ### Listing all customers : `listo`
 
-Shows a list of all orders
+Shows a list of all orders.
 
-Format: `listo [s or f/STATUS]`
+Format: `listo [s/{created|name|status}] [f/STATUS]`
 
-* If `listo s`, then sort by status, starting from pending, followed by paid, shipped and received
+* Lists all orders with the specified sorting option.
+* By default, orders are sorted by their created date
 * If `listo f/STATUS` then show only the given status
 
 Examples:
-* `listo` shows all orders.
-* `listo s` shows all orders, sorted by status.
-* `listo f/pending` shows all orders with "pending" status.
+* `listo` lists all orders sorted by created date.
+* `listo s/status` lists all orders sorted by status.
+* `listo f/pending` lists all orders with "pending" status.
 
 ### Editing an order : `edito`
 

--- a/src/main/java/seedu/loyaltylift/logic/commands/FindOrderCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/FindOrderCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.loyaltylift.commons.core.Messages;
 import seedu.loyaltylift.model.Model;
+import seedu.loyaltylift.model.order.Order;
 import seedu.loyaltylift.model.order.OrderNameContainsKeywordsPredicate;
 
 /**
@@ -28,6 +29,7 @@ public class FindOrderCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+        model.sortFilteredOrderList(Order.SORT_NAME);
         model.updateFilteredOrderList(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_ORDERS_LISTED_OVERVIEW, model.getFilteredOrderList().size()));

--- a/src/main/java/seedu/loyaltylift/logic/commands/ListOrderCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/ListOrderCommand.java
@@ -1,9 +1,13 @@
 package seedu.loyaltylift.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_SORT;
 import static seedu.loyaltylift.model.Model.PREDICATE_SHOW_ALL_ORDERS;
 
+import java.util.Comparator;
+
 import seedu.loyaltylift.model.Model;
+import seedu.loyaltylift.model.order.Order;
 
 /**
  * Lists all orders in LoyaltyLift to the user.
@@ -12,13 +16,32 @@ public class ListOrderCommand extends Command {
 
     public static final String COMMAND_WORD = "listo";
 
-    public static final String MESSAGE_SUCCESS = "Listed all orders";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all orders with an optional sort option "
+        + "(created date by default) and displays them as a list with index numbers.\n"
+        + "Parameters: [" + PREFIX_SORT + "{created|name|status}]\n"
+        + "Example: " + COMMAND_WORD + " s/status";
 
+    public static final String MESSAGE_SUCCESS = "Listed all orders";
+    public static final String MESSAGE_INVALID_SORT = "Unrecognized sort option";
+
+    private final Comparator<Order> comparator;
+
+    public ListOrderCommand(Comparator<Order> comparator) {
+        this.comparator = comparator;
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+        model.sortFilteredOrderList(comparator);
         model.updateFilteredOrderList(PREDICATE_SHOW_ALL_ORDERS);
         return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ListOrderCommand // instanceof handles nulls
+                && comparator.equals(((ListOrderCommand) other).comparator)); // state check
     }
 }

--- a/src/main/java/seedu/loyaltylift/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/AddressBookParser.java
@@ -22,6 +22,7 @@ import seedu.loyaltylift.logic.commands.FindCustomerCommand;
 import seedu.loyaltylift.logic.commands.FindOrderCommand;
 import seedu.loyaltylift.logic.commands.HelpCommand;
 import seedu.loyaltylift.logic.commands.ListCustomerCommand;
+import seedu.loyaltylift.logic.commands.ListOrderCommand;
 import seedu.loyaltylift.logic.commands.MarkCustomerCommand;
 import seedu.loyaltylift.logic.commands.SetCustomerNoteCommand;
 import seedu.loyaltylift.logic.commands.SetOrderNoteCommand;
@@ -119,6 +120,9 @@ public class AddressBookParser {
 
         case FindOrderCommand.COMMAND_WORD:
             return new FindOrderCommandParser().parse(arguments);
+
+        case ListOrderCommand.COMMAND_WORD:
+            return new ListOrderCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/loyaltylift/logic/parser/ListOrderCommandParser.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/ListOrderCommandParser.java
@@ -5,29 +5,29 @@ import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_SORT;
 import java.util.Comparator;
 import java.util.stream.Stream;
 
-import seedu.loyaltylift.logic.commands.ListCustomerCommand;
+import seedu.loyaltylift.logic.commands.ListOrderCommand;
 import seedu.loyaltylift.logic.parser.exceptions.ParseException;
-import seedu.loyaltylift.model.customer.Customer;
+import seedu.loyaltylift.model.order.Order;
 
 /**
- * Parses input arguments and creates a new ListCustomerCommand object
+ * Parses input arguments and creates a new ListOrderCommand object
  */
-public class ListCustomerCommandParser implements Parser<ListCustomerCommand> {
+public class ListOrderCommandParser implements Parser<ListOrderCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the ListCustomerCommand
-     * and returns a ListCustomerCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the ListOrderCommand
+     * and returns a ListOrderCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public ListCustomerCommand parse(String args) throws ParseException {
+    public ListOrderCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_SORT);
 
-        Comparator<Customer> comparator = Customer.SORT_NAME;
+        Comparator<Order> comparator = Order.SORT_CREATED_DATE;
         if (arePrefixesPresent(argMultimap, PREFIX_SORT)) {
-            comparator = ParserUtil.parseCustomerSortOption(argMultimap.getValue(PREFIX_SORT).orElse(""));
+            comparator = ParserUtil.parseOrderSortOption(argMultimap.getValue(PREFIX_SORT).orElse(""));
         }
 
-        return new ListCustomerCommand(comparator);
+        return new ListOrderCommand(comparator);
     }
 
     /**

--- a/src/main/java/seedu/loyaltylift/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/ParserUtil.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import seedu.loyaltylift.commons.core.index.Index;
 import seedu.loyaltylift.commons.util.StringUtil;
 import seedu.loyaltylift.logic.commands.ListCustomerCommand;
+import seedu.loyaltylift.logic.commands.ListOrderCommand;
 import seedu.loyaltylift.logic.parser.exceptions.ParseException;
 import seedu.loyaltylift.model.attribute.Address;
 import seedu.loyaltylift.model.attribute.Name;
@@ -19,6 +20,7 @@ import seedu.loyaltylift.model.customer.CustomerType;
 import seedu.loyaltylift.model.customer.Email;
 import seedu.loyaltylift.model.customer.Phone;
 import seedu.loyaltylift.model.customer.Points;
+import seedu.loyaltylift.model.order.Order;
 import seedu.loyaltylift.model.order.Quantity;
 import seedu.loyaltylift.model.tag.Tag;
 
@@ -212,10 +214,10 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String sortOption} into a {@code Comparator<T>}.
+     * Parses a {@code String sortOption} into a {@code Comparator<Customer>}.
      * @throws ParseException if the given {@code attribute} is invalid.
      */
-    public static Comparator<Customer> parseSortOption(String sortOption) throws ParseException {
+    public static Comparator<Customer> parseCustomerSortOption(String sortOption) throws ParseException {
         requireNonNull(sortOption);
         String trimmedAttribute = sortOption.trim();
         switch (trimmedAttribute) {
@@ -225,6 +227,25 @@ public class ParserUtil {
             return Customer.SORT_POINTS;
         default:
             throw new ParseException(ListCustomerCommand.MESSAGE_INVALID_SORT);
+        }
+    }
+
+    /**
+     * Parses a {@code String sortOption} into a {@code Comparator<Order>}.
+     * @throws ParseException if the given {@code attribute} is invalid.
+     */
+    public static Comparator<Order> parseOrderSortOption(String sortOption) throws ParseException {
+        requireNonNull(sortOption);
+        String trimmedAttribute = sortOption.trim();
+        switch (trimmedAttribute) {
+        case "created":
+            return Order.SORT_CREATED_DATE;
+        case "name":
+            return Order.SORT_NAME;
+        case "status":
+            return Order.SORT_STATUS;
+        default:
+            throw new ParseException(ListOrderCommand.MESSAGE_INVALID_SORT);
         }
     }
 }

--- a/src/main/java/seedu/loyaltylift/model/Model.java
+++ b/src/main/java/seedu/loyaltylift/model/Model.java
@@ -128,6 +128,12 @@ public interface Model {
      */
     void updateFilteredOrderList(Predicate<Order> predicate);
 
+    /**
+     * Sorts the filtered order list using the given {@code comparator}.
+     * @throws NullPointerException if {@code comparator} is null.
+     */
+    void sortFilteredOrderList(Comparator<Order> comparator);
+
     /** Returns an unmodifiable view of the filtered customer's order list */
     ObservableList<Order> getFilteredCustomerOrderList();
 

--- a/src/main/java/seedu/loyaltylift/model/ModelManager.java
+++ b/src/main/java/seedu/loyaltylift/model/ModelManager.java
@@ -24,10 +24,15 @@ public class ModelManager implements Model {
 
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
+
+    // filtered lists
     private final FilteredList<Customer> filteredCustomers;
-    private final SortedList<Customer> sortedCustomers;
     private final FilteredList<Order> filteredOrders;
     private final FilteredList<Order> filteredCustomerOrders;
+
+    // sorted lists
+    private final SortedList<Customer> sortedCustomers;
+    private final SortedList<Order> sortedOrders;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -43,6 +48,7 @@ public class ModelManager implements Model {
         filteredOrders = new FilteredList<>(this.addressBook.getOrderList());
         filteredCustomerOrders = new FilteredList<>(this.addressBook.getOrderList());
         sortedCustomers = new SortedList<>(filteredCustomers, Customer.SORT_NAME);
+        sortedOrders = new SortedList<>(filteredOrders, Order.SORT_CREATED_DATE);
     }
 
     public ModelManager() {
@@ -178,7 +184,7 @@ public class ModelManager implements Model {
      */
     @Override
     public ObservableList<Order> getFilteredOrderList() {
-        return filteredOrders;
+        return sortedOrders;
     }
 
     @Override
@@ -196,6 +202,11 @@ public class ModelManager implements Model {
     public void updateFilteredCustomerOrderList(Customer customer) {
         requireNonNull(customer);
         filteredCustomerOrders.setPredicate((order) -> order.getCustomer().equals(customer));
+    }
+
+    @Override
+    public void sortFilteredOrderList(Comparator<Order> comparator) {
+        sortedOrders.setComparator(comparator);
     }
 
     @Override

--- a/src/main/java/seedu/loyaltylift/model/order/CreatedDate.java
+++ b/src/main/java/seedu/loyaltylift/model/order/CreatedDate.java
@@ -10,7 +10,7 @@ import java.time.format.DateTimeFormatter;
  * Represents an Order's created date in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidCreatedDate(String)}
  */
-public class CreatedDate {
+public class CreatedDate implements Comparable<CreatedDate> {
 
     public static final String MESSAGE_CONSTRAINTS = "CreatedDate can be any date not in the future";
     public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy/MM/dd");
@@ -51,6 +51,11 @@ public class CreatedDate {
     @Override
     public int hashCode() {
         return value.hashCode();
+    }
+
+    @Override
+    public int compareTo(CreatedDate o) {
+        return value.compareTo(o.value);
     }
 
 }

--- a/src/main/java/seedu/loyaltylift/model/order/Order.java
+++ b/src/main/java/seedu/loyaltylift/model/order/Order.java
@@ -17,7 +17,12 @@ import seedu.loyaltylift.model.customer.Customer;
  */
 public class Order {
 
+    // Comparators
     public static final Comparator<Order> SORT_CREATED_DATE = Comparator.comparing(Order::getCreatedDate);
+    public static final Comparator<Order> SORT_NAME = Comparator.comparing(Order::getName)
+            .thenComparing(SORT_CREATED_DATE);
+    public static final Comparator<Order> SORT_STATUS = Comparator.comparing(Order::getStatus)
+            .thenComparing(SORT_CREATED_DATE);
 
     private final Customer customer;
     private final Name name;

--- a/src/main/java/seedu/loyaltylift/model/order/Order.java
+++ b/src/main/java/seedu/loyaltylift/model/order/Order.java
@@ -3,6 +3,7 @@ package seedu.loyaltylift.model.order;
 import static seedu.loyaltylift.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.Objects;
 
 import seedu.loyaltylift.model.attribute.Address;
@@ -15,6 +16,8 @@ import seedu.loyaltylift.model.customer.Customer;
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class Order {
+
+    public static final Comparator<Order> SORT_CREATED_DATE = Comparator.comparing(Order::getCreatedDate);
 
     private final Customer customer;
     private final Name name;

--- a/src/main/java/seedu/loyaltylift/model/order/Status.java
+++ b/src/main/java/seedu/loyaltylift/model/order/Status.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 /**
  * Represents the collection of {@code StatusUpdate} of an Order.
  */
-public class Status {
+public class Status implements Comparable<Status> {
 
     public static final String MESSAGE_CONSTRAINTS = "Status updates should not be empty";
     private final List<StatusUpdate> statusUpdates;
@@ -104,4 +104,10 @@ public class Status {
     public String toString() {
         return statusUpdates.toString();
     }
+
+    @Override
+    public int compareTo(Status o) {
+        return getLatestStatus().compareTo(o.getLatestStatus());
+    }
+
 }

--- a/src/test/java/seedu/loyaltylift/logic/commands/AddCustomerCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/AddCustomerCommandTest.java
@@ -188,6 +188,11 @@ public class AddCustomerCommandTest {
         }
 
         @Override
+        public void sortFilteredOrderList(Comparator<Order> comparator) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Order> getFilteredCustomerOrderList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/loyaltylift/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/CommandTestUtil.java
@@ -20,6 +20,7 @@ import seedu.loyaltylift.model.AddressBook;
 import seedu.loyaltylift.model.Model;
 import seedu.loyaltylift.model.customer.Customer;
 import seedu.loyaltylift.model.customer.CustomerNameContainsKeywordsPredicate;
+import seedu.loyaltylift.model.order.Order;
 import seedu.loyaltylift.testutil.EditCustomerDescriptorBuilder;
 
 /**
@@ -145,6 +146,7 @@ public class CommandTestUtil {
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
         assertEquals(expectedFilteredList, actualModel.getFilteredCustomerList());
     }
+
     /**
      * Updates {@code model}'s filtered list to show only the customer at the given {@code targetIndex} in the
      * {@code model}'s address book.
@@ -157,6 +159,19 @@ public class CommandTestUtil {
         model.updateFilteredCustomerList(new CustomerNameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredCustomerList().size());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show only the order at the given {@code targetIndex} in the
+     * {@code model}'s address book.
+     */
+    public static void showOrderAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredOrderList().size());
+
+        Order order = model.getFilteredOrderList().get(targetIndex.getZeroBased());
+        model.updateFilteredOrderList(a -> a == order);
+
+        assertEquals(1, model.getFilteredOrderList().size());
     }
 
 }

--- a/src/test/java/seedu/loyaltylift/logic/commands/FindOrderCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/FindOrderCommandTest.java
@@ -12,12 +12,14 @@ import static seedu.loyaltylift.testutil.TypicalOrders.ORDER_D;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.loyaltylift.model.Model;
 import seedu.loyaltylift.model.ModelManager;
 import seedu.loyaltylift.model.UserPrefs;
+import seedu.loyaltylift.model.order.Order;
 import seedu.loyaltylift.model.order.OrderNameContainsKeywordsPredicate;
 
 /**
@@ -71,7 +73,9 @@ public class FindOrderCommandTest {
         FindOrderCommand command = new FindOrderCommand(predicate);
         expectedModel.updateFilteredOrderList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(ORDER_A, ORDER_C, ORDER_D), model.getFilteredOrderList());
+        List<Order> expectedList = Arrays.asList(ORDER_A, ORDER_C, ORDER_D);
+        expectedList.sort(Order.SORT_NAME);
+        assertEquals(expectedList, model.getFilteredOrderList());
     }
 
     /**

--- a/src/test/java/seedu/loyaltylift/logic/commands/ListOrderCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/ListOrderCommandTest.java
@@ -1,0 +1,64 @@
+package seedu.loyaltylift.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.loyaltylift.logic.commands.CommandTestUtil.showOrderAtIndex;
+import static seedu.loyaltylift.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.loyaltylift.testutil.TypicalIndexes.INDEX_FIRST;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.loyaltylift.model.Model;
+import seedu.loyaltylift.model.ModelManager;
+import seedu.loyaltylift.model.UserPrefs;
+import seedu.loyaltylift.model.order.Order;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListOrderCommand.
+ */
+public class ListOrderCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void equals() {
+        ListOrderCommand listSortCreatedDateCommand = new ListOrderCommand(Order.SORT_CREATED_DATE);
+        ListOrderCommand listSortStatusCommand = new ListOrderCommand(Order.SORT_STATUS);
+
+        // same object -> returns true
+        assertTrue(listSortCreatedDateCommand.equals(listSortCreatedDateCommand));
+
+        // same comparator -> returns true
+        ListOrderCommand listSortCreatedDateCommandCopy = new ListOrderCommand(Order.SORT_CREATED_DATE);
+        assertTrue(listSortCreatedDateCommand.equals(listSortCreatedDateCommandCopy));
+
+        // different types -> returns false
+        assertFalse(listSortCreatedDateCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(listSortCreatedDateCommand.equals(null));
+
+        // different comparator -> returns false
+        assertFalse(listSortCreatedDateCommand.equals(listSortStatusCommand));
+    }
+
+    @Test
+    public void execute_listIsNotFiltered_showsSameList() {
+        assertCommandSuccess(new ListOrderCommand(null), model, ListOrderCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_listIsFiltered_showsEverything() {
+        showOrderAtIndex(model, INDEX_FIRST);
+        assertCommandSuccess(new ListOrderCommand(null), model, ListOrderCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+}

--- a/src/test/java/seedu/loyaltylift/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/AddressBookParserTest.java
@@ -6,6 +6,7 @@ import static seedu.loyaltylift.commons.core.Messages.MESSAGE_INVALID_COMMAND_FO
 import static seedu.loyaltylift.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_POINTS;
+import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_SORT;
 import static seedu.loyaltylift.testutil.Assert.assertThrows;
 import static seedu.loyaltylift.testutil.TypicalIndexes.INDEX_FIRST;
 
@@ -28,6 +29,7 @@ import seedu.loyaltylift.logic.commands.FindCustomerCommand;
 import seedu.loyaltylift.logic.commands.FindOrderCommand;
 import seedu.loyaltylift.logic.commands.HelpCommand;
 import seedu.loyaltylift.logic.commands.ListCustomerCommand;
+import seedu.loyaltylift.logic.commands.ListOrderCommand;
 import seedu.loyaltylift.logic.commands.SetCustomerNoteCommand;
 import seedu.loyaltylift.logic.commands.SetOrderNoteCommand;
 import seedu.loyaltylift.logic.commands.SetPointsCommand;
@@ -37,6 +39,7 @@ import seedu.loyaltylift.model.attribute.Note;
 import seedu.loyaltylift.model.customer.Customer;
 import seedu.loyaltylift.model.customer.CustomerNameContainsKeywordsPredicate;
 import seedu.loyaltylift.model.customer.Points;
+import seedu.loyaltylift.model.order.Order;
 import seedu.loyaltylift.model.order.OrderNameContainsKeywordsPredicate;
 import seedu.loyaltylift.testutil.CustomerBuilder;
 import seedu.loyaltylift.testutil.CustomerUtil;
@@ -98,8 +101,14 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_listc() throws Exception {
-        assertTrue(parser.parseCommand(ListCustomerCommand.COMMAND_WORD) instanceof ListCustomerCommand);
-        assertTrue(parser.parseCommand(ListCustomerCommand.COMMAND_WORD + " 3") instanceof ListCustomerCommand);
+        ListCustomerCommand parsedCommand;
+
+        parsedCommand = (ListCustomerCommand) parser.parseCommand(ListCustomerCommand.COMMAND_WORD);
+        assertEquals(new ListCustomerCommand(Customer.SORT_NAME), parsedCommand);
+
+        parsedCommand = (ListCustomerCommand) parser.parseCommand(
+                ListCustomerCommand.COMMAND_WORD + " " + PREFIX_SORT + "points");
+        assertEquals(new ListCustomerCommand(Customer.SORT_POINTS), parsedCommand);
     }
 
     @Test
@@ -170,6 +179,18 @@ public class AddressBookParserTest {
         FindOrderCommand command = (FindOrderCommand) parser.parseCommand(
                 FindOrderCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindOrderCommand(new OrderNameContainsKeywordsPredicate(keywords)), command);
+    }
+
+    @Test
+    public void parseCommand_listo() throws Exception {
+        ListOrderCommand parsedCommand;
+
+        parsedCommand = (ListOrderCommand) parser.parseCommand(ListOrderCommand.COMMAND_WORD);
+        assertEquals(new ListOrderCommand(Order.SORT_CREATED_DATE), parsedCommand);
+
+        parsedCommand = (ListOrderCommand) parser.parseCommand(
+                ListOrderCommand.COMMAND_WORD + " " + PREFIX_SORT + "status");
+        assertEquals(new ListOrderCommand(Order.SORT_STATUS), parsedCommand);
     }
 
     @Test

--- a/src/test/java/seedu/loyaltylift/logic/parser/ListOrderCommandParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/ListOrderCommandParserTest.java
@@ -1,0 +1,28 @@
+package seedu.loyaltylift.logic.parser;
+
+import static seedu.loyaltylift.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.loyaltylift.logic.commands.ListOrderCommand;
+import seedu.loyaltylift.model.order.Order;
+
+public class ListOrderCommandParserTest {
+
+    private ListOrderCommandParser parser = new ListOrderCommandParser();
+
+    @Test
+    public void parse_emptyArgs_returnsListCommand() {
+        // sort by name
+        ListOrderCommand expectedListOrderCommand =
+                new ListOrderCommand(Order.SORT_CREATED_DATE);
+        assertParseSuccess(parser, "    ", expectedListOrderCommand);
+    }
+
+    @Test
+    public void parse_validSortOption_returnsListCommand() {
+        ListOrderCommand expectedCommand = new ListOrderCommand(Order.SORT_CREATED_DATE);
+        assertParseSuccess(parser, "s/created", expectedCommand);
+    }
+
+}

--- a/src/test/java/seedu/loyaltylift/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/ParserUtilTest.java
@@ -20,6 +20,7 @@ import seedu.loyaltylift.model.customer.Customer;
 import seedu.loyaltylift.model.customer.CustomerType;
 import seedu.loyaltylift.model.customer.Email;
 import seedu.loyaltylift.model.customer.Phone;
+import seedu.loyaltylift.model.order.Order;
 import seedu.loyaltylift.model.tag.Tag;
 
 public class ParserUtilTest {
@@ -41,6 +42,8 @@ public class ParserUtilTest {
     private static final String VALID_CUSTOMER_TYPE_ENT = "ent";
     private static final String VALID_SORT_OPTION_NAME = "name";
     private static final String VALID_SORT_OPTION_POINTS = "points";
+    private static final String VALID_SORT_OPTION_CREATED_DATE = "created";
+    private static final String VALID_SORT_OPTION_STATUS = "status";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -220,18 +223,35 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseSortOption_validSortOption() throws Exception {
-        assertEquals(ParserUtil.parseSortOption(VALID_SORT_OPTION_NAME), Customer.SORT_NAME);
-        assertEquals(ParserUtil.parseSortOption(VALID_SORT_OPTION_POINTS), Customer.SORT_POINTS);
+    public void parseCustomerSortOption_validSortOption() throws Exception {
+        assertEquals(ParserUtil.parseCustomerSortOption(VALID_SORT_OPTION_NAME), Customer.SORT_NAME);
+        assertEquals(ParserUtil.parseCustomerSortOption(VALID_SORT_OPTION_POINTS), Customer.SORT_POINTS);
     }
 
     @Test
-    public void parseSortOption_null_throwsNullPointerException() throws Exception {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parseSortOption(null));
+    public void parseCustomerSortOption_null_throwsNullPointerException() throws Exception {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseCustomerSortOption(null));
     }
 
     @Test
-    public void parseSortOption_invalidSortOption_throwsParseException() throws Exception {
-        assertThrows(ParseException.class, () -> ParserUtil.parseSortOption(INVALID_SORT_OPTION));
+    public void parseCustomerSortOption_invalidSortOption_throwsParseException() throws Exception {
+        assertThrows(ParseException.class, () -> ParserUtil.parseCustomerSortOption(INVALID_SORT_OPTION));
+    }
+
+    @Test
+    public void parseOrderSortOption_validSortOption() throws Exception {
+        assertEquals(ParserUtil.parseOrderSortOption(VALID_SORT_OPTION_CREATED_DATE), Order.SORT_CREATED_DATE);
+        assertEquals(ParserUtil.parseOrderSortOption(VALID_SORT_OPTION_NAME), Order.SORT_NAME);
+        assertEquals(ParserUtil.parseOrderSortOption(VALID_SORT_OPTION_STATUS), Order.SORT_STATUS);
+    }
+
+    @Test
+    public void parseOrderSortOption_null_throwsNullPointerException() throws Exception {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseOrderSortOption(null));
+    }
+
+    @Test
+    public void parseOrderSortOption_invalidSortOption_throwsParseException() throws Exception {
+        assertThrows(ParseException.class, () -> ParserUtil.parseOrderSortOption(INVALID_SORT_OPTION));
     }
 }


### PR DESCRIPTION
Updates the `listo` command to accept a sorting option as a parameter:

`listo [s/{created|name|status}]`

Notable changes:

* Orders are now sorted by created date by default
* `CreatedDate` and `Status` now implement `Comparable`
* Added a `SortedList<Order>` to the the model
* The UI now uses the `SortedList` to display the order list
* The comparators to sort the `SortedList` are provided in the `Order` class

Closes #78