### PR TITLE
Filter Orders by Status

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -307,15 +307,16 @@ Examples:
 * addo 4 n/Strawberry ice cream
   * Adds the order 1 x Strawberry ice cream, tags it to customer 4, and sets status to "pending", address is the customer's address.
 
-### Listing all customers : `listo`
+### Listing all orders : `listo`
 
 Shows a list of all orders.
 
 Format: `listo [s/{created|name|status}] [f/STATUS]`
 
 * Lists all orders with the specified sorting option.
-* By default, orders are sorted by their created date
-* If `listo f/STATUS` then show only the given status
+* By default, orders are sorted by their created date.
+* If `f/STATUS` is provided, then show only the given status.
+* `STATUS` is case-insensitive and can be one of: pending, paid, shipped, completed, cancelled.
 
 Examples:
 * `listo` lists all orders sorted by created date.

--- a/src/main/java/seedu/loyaltylift/logic/commands/ListCustomerCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/ListCustomerCommand.java
@@ -26,6 +26,16 @@ public class ListCustomerCommand extends Command {
 
     private final Comparator<Customer> comparator;
 
+    /**
+     * Constructs a default {@code ListCustomerCommand}
+     */
+    public ListCustomerCommand() {
+        this(Customer.SORT_NAME);
+    }
+
+    /**
+     * Constructs a {@code ListCustomerCommand} with the given {@code comparator}
+     */
     public ListCustomerCommand(Comparator<Customer> comparator) {
         this.comparator = comparator;
     }

--- a/src/main/java/seedu/loyaltylift/logic/commands/ListOrderCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/ListOrderCommand.java
@@ -1,10 +1,12 @@
 package seedu.loyaltylift.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_FILTER;
 import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_SORT;
 import static seedu.loyaltylift.model.Model.PREDICATE_SHOW_ALL_ORDERS;
 
 import java.util.Comparator;
+import java.util.function.Predicate;
 
 import seedu.loyaltylift.model.Model;
 import seedu.loyaltylift.model.order.Order;
@@ -18,23 +20,36 @@ public class ListOrderCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all orders with an optional sort option "
         + "(created date by default) and displays them as a list with index numbers.\n"
-        + "Parameters: [" + PREFIX_SORT + "{created|name|status}]\n"
-        + "Example: " + COMMAND_WORD + " s/status";
+        + "Parameters: [" + PREFIX_SORT + "{created|name|status}] + [" + PREFIX_FILTER + "STATUS]\n"
+        + "Example: " + COMMAND_WORD + " s/name f/pending";
 
     public static final String MESSAGE_SUCCESS = "Listed all orders";
     public static final String MESSAGE_INVALID_SORT = "Unrecognized sort option";
+    public static final String MESSAGE_INVALID_FILTER = "Unrecognized filter option";
 
     private final Comparator<Order> comparator;
+    private final Predicate<Order> predicate;
 
-    public ListOrderCommand(Comparator<Order> comparator) {
+    /**
+     * Constructs a default {@code ListOrderCommand}
+     */
+    public ListOrderCommand() {
+        this(Order.SORT_CREATED_DATE, PREDICATE_SHOW_ALL_ORDERS);
+    }
+
+    /**
+     * Constructs a {@code ListOrderCommand} with the given {@code comparator} and {@code predicate}
+     */
+    public ListOrderCommand(Comparator<Order> comparator, Predicate<Order> predicate) {
         this.comparator = comparator;
+        this.predicate = predicate;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.sortFilteredOrderList(comparator);
-        model.updateFilteredOrderList(PREDICATE_SHOW_ALL_ORDERS);
+        model.updateFilteredOrderList(predicate);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 
@@ -42,6 +57,7 @@ public class ListOrderCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof ListOrderCommand // instanceof handles nulls
-                && comparator.equals(((ListOrderCommand) other).comparator)); // state check
+                && comparator.equals(((ListOrderCommand) other).comparator)
+                && predicate.equals(((ListOrderCommand) other).predicate)); // state check
     }
 }

--- a/src/main/java/seedu/loyaltylift/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/AddressBookParser.java
@@ -30,7 +30,6 @@ import seedu.loyaltylift.logic.commands.SetPointsCommand;
 import seedu.loyaltylift.logic.commands.UnmarkCustomerCommand;
 import seedu.loyaltylift.logic.commands.ViewCustomerCommand;
 import seedu.loyaltylift.logic.parser.exceptions.ParseException;
-
 /**
  * Parses user input.
  */

--- a/src/main/java/seedu/loyaltylift/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/CliSyntax.java
@@ -16,5 +16,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_POINTS = new Prefix("pt/");
     public static final Prefix PREFIX_NOTE = new Prefix("nt/");
     public static final Prefix PREFIX_SORT = new Prefix("s/");
+    public static final Prefix PREFIX_FILTER = new Prefix("f/");
 
 }

--- a/src/main/java/seedu/loyaltylift/logic/parser/ListOrderCommandParser.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/ListOrderCommandParser.java
@@ -1,13 +1,18 @@
 package seedu.loyaltylift.logic.parser;
 
+import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_FILTER;
 import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_SORT;
+import static seedu.loyaltylift.model.Model.PREDICATE_SHOW_ALL_ORDERS;
 
 import java.util.Comparator;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import seedu.loyaltylift.logic.commands.ListOrderCommand;
 import seedu.loyaltylift.logic.parser.exceptions.ParseException;
 import seedu.loyaltylift.model.order.Order;
+import seedu.loyaltylift.model.order.OrderStatusPredicate;
+import seedu.loyaltylift.model.order.StatusValue;
 
 /**
  * Parses input arguments and creates a new ListOrderCommand object
@@ -20,14 +25,20 @@ public class ListOrderCommandParser implements Parser<ListOrderCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public ListOrderCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_SORT);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_SORT, PREFIX_FILTER);
 
         Comparator<Order> comparator = Order.SORT_CREATED_DATE;
         if (arePrefixesPresent(argMultimap, PREFIX_SORT)) {
             comparator = ParserUtil.parseOrderSortOption(argMultimap.getValue(PREFIX_SORT).orElse(""));
         }
 
-        return new ListOrderCommand(comparator);
+        Predicate<Order> predicate = PREDICATE_SHOW_ALL_ORDERS;
+        if (arePrefixesPresent(argMultimap, PREFIX_FILTER)) {
+            StatusValue status = ParserUtil.parseStatusValue(argMultimap.getValue(PREFIX_FILTER).orElse(""));
+            predicate = new OrderStatusPredicate(status);
+        }
+
+        return new ListOrderCommand(comparator, predicate);
     }
 
     /**

--- a/src/main/java/seedu/loyaltylift/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/ParserUtil.java
@@ -22,6 +22,7 @@ import seedu.loyaltylift.model.customer.Phone;
 import seedu.loyaltylift.model.customer.Points;
 import seedu.loyaltylift.model.order.Order;
 import seedu.loyaltylift.model.order.Quantity;
+import seedu.loyaltylift.model.order.StatusValue;
 import seedu.loyaltylift.model.tag.Tag;
 
 /**
@@ -246,6 +247,19 @@ public class ParserUtil {
             return Order.SORT_STATUS;
         default:
             throw new ParseException(ListOrderCommand.MESSAGE_INVALID_SORT);
+        }
+    }
+
+    /**
+     * Parses a {@code String statusValue} into a {@code StatusValue}.
+     * @throws ParseException if the given {@code attribute} is invalid.
+     */
+    public static StatusValue parseStatusValue(String statusValue) throws ParseException {
+        requireNonNull(statusValue);
+        try {
+            return StatusValue.fromString(statusValue.trim());
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(ListOrderCommand.MESSAGE_INVALID_FILTER);
         }
     }
 }

--- a/src/main/java/seedu/loyaltylift/model/order/OrderNameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/loyaltylift/model/order/OrderNameContainsKeywordsPredicate.java
@@ -6,7 +6,7 @@ import java.util.function.Predicate;
 import seedu.loyaltylift.commons.util.StringUtil;
 
 /**
- * Tests that a {@code Customer}'s {@code Name} matches any of the keywords given.
+ * Tests that an {@code Order}'s {@code Name} matches any of the keywords given.
  */
 public class OrderNameContainsKeywordsPredicate implements Predicate<Order> {
     private final List<String> keywords;

--- a/src/main/java/seedu/loyaltylift/model/order/OrderStatusPredicate.java
+++ b/src/main/java/seedu/loyaltylift/model/order/OrderStatusPredicate.java
@@ -1,0 +1,27 @@
+package seedu.loyaltylift.model.order;
+
+import java.util.function.Predicate;
+
+/**
+ * Tests that an {@code Order}'s latest {@code Status} matches the given status.
+ */
+public class OrderStatusPredicate implements Predicate<Order> {
+    private final StatusValue status;
+
+    public OrderStatusPredicate(StatusValue status) {
+        this.status = status;
+    }
+
+    @Override
+    public boolean test(Order order) {
+        return order.getStatus().getLatestStatus().getStatusValue().equals(status);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof OrderStatusPredicate // instanceof handles nulls
+                && status.equals(((OrderStatusPredicate) other).status)); // state check
+    }
+
+}

--- a/src/test/java/seedu/loyaltylift/logic/commands/ListCustomerCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/ListCustomerCommandTest.java
@@ -31,24 +31,24 @@ public class ListCustomerCommandTest {
 
     @Test
     public void equals() {
-        ListCustomerCommand listSortNameCommand = new ListCustomerCommand(Customer.SORT_NAME);
+        ListCustomerCommand listCommand = new ListCustomerCommand();
         ListCustomerCommand listSortOrderCommand = new ListCustomerCommand(Customer.SORT_POINTS);
 
         // same object -> returns true
-        assertTrue(listSortNameCommand.equals(listSortNameCommand));
+        assertTrue(listCommand.equals(listCommand));
 
         // same comparator -> returns true
-        ListCustomerCommand listSortNameCommandCopy = new ListCustomerCommand(Customer.SORT_NAME);
-        assertTrue(listSortNameCommand.equals(listSortNameCommandCopy));
+        ListCustomerCommand listCommandCopy = new ListCustomerCommand();
+        assertTrue(listCommand.equals(listCommandCopy));
 
         // different types -> returns false
-        assertFalse(listSortNameCommand.equals(1));
+        assertFalse(listCommand.equals(1));
 
         // null -> returns false
-        assertFalse(listSortNameCommand.equals(null));
+        assertFalse(listCommand.equals(null));
 
         // different comparator -> returns false
-        assertFalse(listSortNameCommand.equals(listSortOrderCommand));
+        assertFalse(listCommand.equals(listSortOrderCommand));
     }
 
     @Test

--- a/src/test/java/seedu/loyaltylift/logic/commands/ListOrderCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/ListOrderCommandTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.loyaltylift.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.loyaltylift.logic.commands.CommandTestUtil.showOrderAtIndex;
+import static seedu.loyaltylift.model.Model.PREDICATE_SHOW_ALL_ORDERS;
 import static seedu.loyaltylift.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.loyaltylift.testutil.TypicalIndexes.INDEX_FIRST;
 
@@ -14,6 +15,8 @@ import seedu.loyaltylift.model.Model;
 import seedu.loyaltylift.model.ModelManager;
 import seedu.loyaltylift.model.UserPrefs;
 import seedu.loyaltylift.model.order.Order;
+import seedu.loyaltylift.model.order.OrderStatusPredicate;
+import seedu.loyaltylift.model.order.StatusValue;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListOrderCommand.
@@ -31,34 +34,44 @@ public class ListOrderCommandTest {
 
     @Test
     public void equals() {
-        ListOrderCommand listSortCreatedDateCommand = new ListOrderCommand(Order.SORT_CREATED_DATE);
-        ListOrderCommand listSortStatusCommand = new ListOrderCommand(Order.SORT_STATUS);
+        ListOrderCommand listCommand = new ListOrderCommand();
+        ListOrderCommand listSortStatusCommand = new ListOrderCommand(
+                Order.SORT_STATUS, PREDICATE_SHOW_ALL_ORDERS);
+        ListOrderCommand listSortCreatedDatePendingCommand = new ListOrderCommand(
+                Order.SORT_CREATED_DATE, new OrderStatusPredicate(StatusValue.PENDING));
 
         // same object -> returns true
-        assertTrue(listSortCreatedDateCommand.equals(listSortCreatedDateCommand));
+        assertTrue(listCommand.equals(listCommand));
 
-        // same comparator -> returns true
-        ListOrderCommand listSortCreatedDateCommandCopy = new ListOrderCommand(Order.SORT_CREATED_DATE);
-        assertTrue(listSortCreatedDateCommand.equals(listSortCreatedDateCommandCopy));
+        // same comparator and predicate -> returns true
+        ListOrderCommand listCommandCopy = new ListOrderCommand();
+        assertTrue(listCommand.equals(listCommandCopy));
+
+        ListOrderCommand listSortCreatedDatePendingCommandCopy = new ListOrderCommand(
+                Order.SORT_CREATED_DATE, new OrderStatusPredicate(StatusValue.PENDING));
+        assertTrue(listSortCreatedDatePendingCommand.equals(listSortCreatedDatePendingCommandCopy));
 
         // different types -> returns false
-        assertFalse(listSortCreatedDateCommand.equals(1));
+        assertFalse(listCommand.equals(1));
 
         // null -> returns false
-        assertFalse(listSortCreatedDateCommand.equals(null));
+        assertFalse(listCommand.equals(null));
 
         // different comparator -> returns false
-        assertFalse(listSortCreatedDateCommand.equals(listSortStatusCommand));
+        assertFalse(listCommand.equals(listSortStatusCommand));
+
+        // different predicate -> returns false
+        assertFalse(listCommand.equals(listSortCreatedDatePendingCommand));
     }
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListOrderCommand(null), model, ListOrderCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListOrderCommand(), model, ListOrderCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showOrderAtIndex(model, INDEX_FIRST);
-        assertCommandSuccess(new ListOrderCommand(null), model, ListOrderCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListOrderCommand(), model, ListOrderCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/loyaltylift/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/AddressBookParserTest.java
@@ -4,9 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.loyaltylift.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.loyaltylift.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_FILTER;
 import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_POINTS;
 import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_SORT;
+import static seedu.loyaltylift.model.Model.PREDICATE_SHOW_ALL_ORDERS;
 import static seedu.loyaltylift.testutil.Assert.assertThrows;
 import static seedu.loyaltylift.testutil.TypicalIndexes.INDEX_FIRST;
 
@@ -41,6 +43,8 @@ import seedu.loyaltylift.model.customer.CustomerNameContainsKeywordsPredicate;
 import seedu.loyaltylift.model.customer.Points;
 import seedu.loyaltylift.model.order.Order;
 import seedu.loyaltylift.model.order.OrderNameContainsKeywordsPredicate;
+import seedu.loyaltylift.model.order.OrderStatusPredicate;
+import seedu.loyaltylift.model.order.StatusValue;
 import seedu.loyaltylift.testutil.CustomerBuilder;
 import seedu.loyaltylift.testutil.CustomerUtil;
 import seedu.loyaltylift.testutil.EditCustomerDescriptorBuilder;
@@ -184,13 +188,26 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_listo() throws Exception {
         ListOrderCommand parsedCommand;
+        OrderStatusPredicate pendingPredicate = new OrderStatusPredicate(StatusValue.PENDING);
 
+        // no args
         parsedCommand = (ListOrderCommand) parser.parseCommand(ListOrderCommand.COMMAND_WORD);
-        assertEquals(new ListOrderCommand(Order.SORT_CREATED_DATE), parsedCommand);
+        assertEquals(new ListOrderCommand(), parsedCommand);
 
+        // sort status
         parsedCommand = (ListOrderCommand) parser.parseCommand(
                 ListOrderCommand.COMMAND_WORD + " " + PREFIX_SORT + "status");
-        assertEquals(new ListOrderCommand(Order.SORT_STATUS), parsedCommand);
+        assertEquals(new ListOrderCommand(Order.SORT_STATUS, PREDICATE_SHOW_ALL_ORDERS), parsedCommand);
+
+        // filter pending
+        parsedCommand = (ListOrderCommand) parser.parseCommand(
+                ListOrderCommand.COMMAND_WORD + " " + PREFIX_FILTER + "pending");
+        assertEquals(new ListOrderCommand(Order.SORT_CREATED_DATE, pendingPredicate), parsedCommand);
+
+        // sort name and filter pending
+        parsedCommand = (ListOrderCommand) parser.parseCommand(
+                ListOrderCommand.COMMAND_WORD + " " + PREFIX_SORT + "name " + PREFIX_FILTER + "pending");
+        assertEquals(new ListOrderCommand(Order.SORT_NAME, pendingPredicate), parsedCommand);
     }
 
     @Test

--- a/src/test/java/seedu/loyaltylift/logic/parser/ListCustomerCommandParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/ListCustomerCommandParserTest.java
@@ -1,5 +1,7 @@
 package seedu.loyaltylift.logic.parser;
 
+import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_SORT;
+import static seedu.loyaltylift.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.loyaltylift.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.jupiter.api.Test;
@@ -12,7 +14,7 @@ public class ListCustomerCommandParserTest {
     private ListCustomerCommandParser parser = new ListCustomerCommandParser();
 
     @Test
-    public void parse_emptyArgs_returnsListCommand() {
+    public void parse_emptyArgs_success() {
         // sort by name
         ListCustomerCommand expectedListCustomerCommand =
                 new ListCustomerCommand(Customer.SORT_NAME);
@@ -20,10 +22,15 @@ public class ListCustomerCommandParserTest {
     }
 
     @Test
-    public void parse_validSortOption_returnsListCommand() {
+    public void parse_validSortOption_success() {
         ListCustomerCommand expectedListSortNameCustomerCommand =
-                new ListCustomerCommand(Customer.SORT_NAME);
-        assertParseSuccess(parser, "s/name", expectedListSortNameCustomerCommand);
+                new ListCustomerCommand(Customer.SORT_POINTS);
+        assertParseSuccess(parser, " " + PREFIX_SORT + "points", expectedListSortNameCustomerCommand);
+    }
+
+    @Test
+    public void parse_invalidSortOption_failure() {
+        assertParseFailure(parser, " " + PREFIX_SORT + "invalid", ListCustomerCommand.MESSAGE_INVALID_SORT);
     }
 
 }

--- a/src/test/java/seedu/loyaltylift/logic/parser/ListOrderCommandParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/ListOrderCommandParserTest.java
@@ -1,28 +1,53 @@
 package seedu.loyaltylift.logic.parser;
 
+import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_FILTER;
+import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_SORT;
+import static seedu.loyaltylift.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.loyaltylift.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.loyaltylift.model.Model.PREDICATE_SHOW_ALL_ORDERS;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.loyaltylift.logic.commands.ListOrderCommand;
 import seedu.loyaltylift.model.order.Order;
+import seedu.loyaltylift.model.order.OrderStatusPredicate;
+import seedu.loyaltylift.model.order.StatusValue;
 
 public class ListOrderCommandParserTest {
 
     private ListOrderCommandParser parser = new ListOrderCommandParser();
 
     @Test
-    public void parse_emptyArgs_returnsListCommand() {
-        // sort by name
-        ListOrderCommand expectedListOrderCommand =
-                new ListOrderCommand(Order.SORT_CREATED_DATE);
+    public void parse_emptyArgs_success() {
+        ListOrderCommand expectedListOrderCommand = new ListOrderCommand();
         assertParseSuccess(parser, "    ", expectedListOrderCommand);
     }
 
     @Test
-    public void parse_validSortOption_returnsListCommand() {
-        ListOrderCommand expectedCommand = new ListOrderCommand(Order.SORT_CREATED_DATE);
-        assertParseSuccess(parser, "s/created", expectedCommand);
+    public void parse_validArgs_success() {
+        ListOrderCommand expectedCommand;
+        OrderStatusPredicate pendingPredicate = new OrderStatusPredicate(StatusValue.PENDING);
+
+        // sort status
+        expectedCommand = new ListOrderCommand(Order.SORT_STATUS, PREDICATE_SHOW_ALL_ORDERS);
+        assertParseSuccess(parser, " " + PREFIX_SORT + "status", expectedCommand);
+
+        // filter pending
+        expectedCommand = new ListOrderCommand(Order.SORT_CREATED_DATE, pendingPredicate);
+        assertParseSuccess(parser, " " + PREFIX_FILTER + "pending", expectedCommand);
+
+        // sort status and filter pending
+        expectedCommand = new ListOrderCommand(Order.SORT_STATUS, pendingPredicate);
+        assertParseSuccess(parser, " " + PREFIX_SORT + "status " + PREFIX_FILTER + "pending", expectedCommand);
+    }
+
+    @Test
+    public void parse_invalidArgs_failure() {
+        // invalid sort
+        assertParseFailure(parser, " " + PREFIX_SORT + "invalid", ListOrderCommand.MESSAGE_INVALID_SORT);
+
+        // invalid filter
+        assertParseFailure(parser, " " + PREFIX_FILTER + "invalid", ListOrderCommand.MESSAGE_INVALID_FILTER);
     }
 
 }

--- a/src/test/java/seedu/loyaltylift/model/order/OrderStatusPredicateTest.java
+++ b/src/test/java/seedu/loyaltylift/model/order/OrderStatusPredicateTest.java
@@ -1,0 +1,54 @@
+package seedu.loyaltylift.model.order;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.loyaltylift.testutil.OrderBuilder;
+
+public class OrderStatusPredicateTest {
+
+    @Test
+    public void equals() {
+
+        OrderStatusPredicate pendingPredicate = new OrderStatusPredicate(StatusValue.PENDING);
+        OrderStatusPredicate completedPredicate = new OrderStatusPredicate(StatusValue.COMPLETED);
+
+        // same object -> returns true
+        assertTrue(pendingPredicate.equals(pendingPredicate));
+
+        // same predicate -> returns true
+        OrderStatusPredicate pendingPredicateCopy = new OrderStatusPredicate(StatusValue.PENDING);
+        assertTrue(pendingPredicate.equals(pendingPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(pendingPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(pendingPredicate.equals(null));
+
+        // different predicate -> returns false
+        assertFalse(pendingPredicate.equals(completedPredicate));
+    }
+
+    @Test
+    public void test_matchingStatus_returnsTrue() {
+        OrderStatusPredicate pendingPredicate = new OrderStatusPredicate(StatusValue.PENDING);
+        assertTrue(pendingPredicate.test(new OrderBuilder().build()));
+
+        OrderStatusPredicate paidPredicate = new OrderStatusPredicate(StatusValue.PAID);
+        assertTrue(paidPredicate.test(new OrderBuilder().withNextStatus("2023/01/01").build()));
+    }
+
+    @Test
+    public void test_nonMatchingStatus_returnsFalse() {
+        // earlier status
+        OrderStatusPredicate paidPredicate = new OrderStatusPredicate(StatusValue.PAID);
+        assertFalse(paidPredicate.test(new OrderBuilder().build()));
+
+        // later status
+        OrderStatusPredicate pendingPredicate = new OrderStatusPredicate(StatusValue.PENDING);
+        assertFalse(pendingPredicate.test(new OrderBuilder().withNextStatus("2023/01/01").build()));
+    }
+}


### PR DESCRIPTION
Adds a filter option to the `listo` command to filter orders by status

```
listo [s/{created|name|status}] [f/STATUS]
```

Closes #85