### PR TITLE
Edited ListCustomerCommand to allow for filter option.

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -80,7 +80,7 @@ Adds a customer to the current list.
 Format: `addc [ct/{ind/ent}] n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS`
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
-Customers are 'Individiuals' by default!
+Customers are 'Individuals' by default!
 ind - Individuals
 ent - Enterprise
 </div>
@@ -94,14 +94,16 @@ Examples:
 
 Shows a list of all customers.
 
-Format: `listc [s/{name|points}]`
+Format: `listc [s/{name|points}] [f/marked]`
 
 * Lists all customer with the specified sorting option.
 * Be default, customers are sorted by name
+* If `f/marked` is provided, then shows only bookmarked customers.
 
 Examples:
 * `listc` lists all customers sorted by name
 * `listc s/points` lists all customers sorted by points
+* `listc f/marked` lists all bookmarked customers. 
 
 ### View a customer : `viewc`
 

--- a/src/main/java/seedu/loyaltylift/logic/commands/ListCustomerCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/ListCustomerCommand.java
@@ -1,10 +1,12 @@
 package seedu.loyaltylift.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_FILTER;
 import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_SORT;
 import static seedu.loyaltylift.model.Model.PREDICATE_SHOW_ALL_CUSTOMERS;
 
 import java.util.Comparator;
+import java.util.function.Predicate;
 
 import seedu.loyaltylift.model.Model;
 import seedu.loyaltylift.model.customer.Customer;
@@ -18,33 +20,36 @@ public class ListCustomerCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all customers with an optional sort option "
             + "(name by default) and displays them as a list with index numbers.\n"
-            + "Parameters: [" + PREFIX_SORT + "{name|points}]\n"
-            + "Example: " + COMMAND_WORD + " s/points";
+            + "Parameters: [" + PREFIX_SORT + "{name|points}] + [" + PREFIX_FILTER + "STATUS\n"
+            + "Example: " + COMMAND_WORD + " s/points f/marked";
 
     public static final String MESSAGE_SUCCESS = "Listed all customers";
     public static final String MESSAGE_INVALID_SORT = "Unrecognized sort option";
+    public static final String MESSAGE_INVALID_FILTER = "Unrecognized filter option";
 
     private final Comparator<Customer> comparator;
+    private final Predicate<Customer> predicate;
 
     /**
      * Constructs a default {@code ListCustomerCommand}
      */
     public ListCustomerCommand() {
-        this(Customer.SORT_NAME);
+        this(Customer.SORT_NAME, PREDICATE_SHOW_ALL_CUSTOMERS);
     }
 
     /**
      * Constructs a {@code ListCustomerCommand} with the given {@code comparator}
      */
-    public ListCustomerCommand(Comparator<Customer> comparator) {
+    public ListCustomerCommand(Comparator<Customer> comparator, Predicate<Customer> predicate) {
         this.comparator = comparator;
+        this.predicate = predicate;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.sortFilteredCustomerList(comparator);
-        model.updateFilteredCustomerList(PREDICATE_SHOW_ALL_CUSTOMERS);
+        model.updateFilteredCustomerList(predicate);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 
@@ -52,6 +57,7 @@ public class ListCustomerCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof ListCustomerCommand // instanceof handles nulls
-                && comparator.equals(((ListCustomerCommand) other).comparator)); // state check
+                && comparator.equals(((ListCustomerCommand) other).comparator)
+                && predicate.equals(((ListCustomerCommand) other).predicate)); // state check
     }
 }

--- a/src/main/java/seedu/loyaltylift/logic/parser/ListCustomerCommandParser.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/ListCustomerCommandParser.java
@@ -1,8 +1,11 @@
 package seedu.loyaltylift.logic.parser;
 
+import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_FILTER;
 import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_SORT;
+import static seedu.loyaltylift.model.Model.PREDICATE_SHOW_ALL_CUSTOMERS;
 
 import java.util.Comparator;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import seedu.loyaltylift.logic.commands.ListCustomerCommand;
@@ -20,14 +23,19 @@ public class ListCustomerCommandParser implements Parser<ListCustomerCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public ListCustomerCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_SORT);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_SORT, PREFIX_FILTER);
 
         Comparator<Customer> comparator = Customer.SORT_NAME;
         if (arePrefixesPresent(argMultimap, PREFIX_SORT)) {
             comparator = ParserUtil.parseCustomerSortOption(argMultimap.getValue(PREFIX_SORT).orElse(""));
         }
 
-        return new ListCustomerCommand(comparator);
+        Predicate<Customer> predicate = PREDICATE_SHOW_ALL_CUSTOMERS;
+        if (arePrefixesPresent(argMultimap, PREFIX_FILTER)) {
+            predicate = ParserUtil.parseCustomerFilterOption(argMultimap.getValue(PREFIX_FILTER).orElse(""));
+        }
+
+        return new ListCustomerCommand(comparator, predicate);
     }
 
     /**

--- a/src/main/java/seedu/loyaltylift/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/ParserUtil.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import seedu.loyaltylift.commons.core.index.Index;
 import seedu.loyaltylift.commons.util.StringUtil;
@@ -228,6 +229,21 @@ public class ParserUtil {
             return Customer.SORT_POINTS;
         default:
             throw new ParseException(ListCustomerCommand.MESSAGE_INVALID_SORT);
+        }
+    }
+
+    /**
+     * Parses a {@code String filterOption} into a {@code Predicate<Customer>}.
+     * @throws ParseException if the given {@code attribute} is invalid.
+     */
+    public static Predicate<Customer> parseCustomerFilterOption(String filterOption) throws ParseException {
+        requireNonNull(filterOption);
+        String trimmedAttribute = filterOption.trim();
+        switch (trimmedAttribute) {
+        case "marked":
+            return Customer.FILTER_SHOW_MARKED;
+        default:
+            throw new ParseException(ListCustomerCommand.MESSAGE_INVALID_FILTER);
         }
     }
 

--- a/src/main/java/seedu/loyaltylift/model/customer/Customer.java
+++ b/src/main/java/seedu/loyaltylift/model/customer/Customer.java
@@ -7,6 +7,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import seedu.loyaltylift.model.attribute.Address;
 import seedu.loyaltylift.model.attribute.Name;
@@ -23,6 +24,9 @@ public class Customer {
     public static final Comparator<Customer> SORT_NAME = Comparator.comparing(Customer::getName);
     public static final Comparator<Customer> SORT_POINTS = Comparator.comparing(Customer::getPoints)
             .reversed().thenComparing(SORT_NAME);
+
+    // Predicates
+    public static final Predicate<Customer> FILTER_SHOW_MARKED = customer -> customer.getMarked().value;
 
     // Identity fields
     private final Name name;

--- a/src/test/java/seedu/loyaltylift/logic/commands/ListCustomerCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/ListCustomerCommandTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.loyaltylift.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.loyaltylift.logic.commands.CommandTestUtil.showCustomerAtIndex;
+import static seedu.loyaltylift.model.Model.PREDICATE_SHOW_ALL_CUSTOMERS;
 import static seedu.loyaltylift.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.loyaltylift.testutil.TypicalIndexes.INDEX_FIRST;
 
@@ -32,7 +33,10 @@ public class ListCustomerCommandTest {
     @Test
     public void equals() {
         ListCustomerCommand listCommand = new ListCustomerCommand();
-        ListCustomerCommand listSortOrderCommand = new ListCustomerCommand(Customer.SORT_POINTS);
+        ListCustomerCommand listSortOrderCommand = new ListCustomerCommand(
+                Customer.SORT_POINTS, PREDICATE_SHOW_ALL_CUSTOMERS);
+        ListCustomerCommand listFilterMarkedCommand = new ListCustomerCommand(
+                Customer.SORT_NAME, Customer.FILTER_SHOW_MARKED);
 
         // same object -> returns true
         assertTrue(listCommand.equals(listCommand));
@@ -49,16 +53,19 @@ public class ListCustomerCommandTest {
 
         // different comparator -> returns false
         assertFalse(listCommand.equals(listSortOrderCommand));
+
+        // different predicate -> returns false
+        assertFalse(listCommand.equals(listFilterMarkedCommand));
     }
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCustomerCommand(null), model, ListCustomerCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCustomerCommand(), model, ListCustomerCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showCustomerAtIndex(model, INDEX_FIRST);
-        assertCommandSuccess(new ListCustomerCommand(null), model, ListCustomerCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCustomerCommand(), model, ListCustomerCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/loyaltylift/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/AddressBookParserTest.java
@@ -8,6 +8,7 @@ import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_FILTER;
 import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_POINTS;
 import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_SORT;
+import static seedu.loyaltylift.model.Model.PREDICATE_SHOW_ALL_CUSTOMERS;
 import static seedu.loyaltylift.model.Model.PREDICATE_SHOW_ALL_ORDERS;
 import static seedu.loyaltylift.testutil.Assert.assertThrows;
 import static seedu.loyaltylift.testutil.TypicalIndexes.INDEX_FIRST;
@@ -108,11 +109,19 @@ public class AddressBookParserTest {
         ListCustomerCommand parsedCommand;
 
         parsedCommand = (ListCustomerCommand) parser.parseCommand(ListCustomerCommand.COMMAND_WORD);
-        assertEquals(new ListCustomerCommand(Customer.SORT_NAME), parsedCommand);
+        assertEquals(new ListCustomerCommand(Customer.SORT_NAME, PREDICATE_SHOW_ALL_CUSTOMERS), parsedCommand);
 
         parsedCommand = (ListCustomerCommand) parser.parseCommand(
                 ListCustomerCommand.COMMAND_WORD + " " + PREFIX_SORT + "points");
-        assertEquals(new ListCustomerCommand(Customer.SORT_POINTS), parsedCommand);
+        assertEquals(new ListCustomerCommand(Customer.SORT_POINTS, PREDICATE_SHOW_ALL_CUSTOMERS), parsedCommand);
+
+        parsedCommand = (ListCustomerCommand) parser.parseCommand(
+                ListCustomerCommand.COMMAND_WORD + " " + PREFIX_FILTER + "marked");
+        assertEquals(new ListCustomerCommand(Customer.SORT_NAME, Customer.FILTER_SHOW_MARKED), parsedCommand);
+
+        parsedCommand = (ListCustomerCommand) parser.parseCommand(ListCustomerCommand.COMMAND_WORD + " "
+                + PREFIX_SORT + "points" + " " + PREFIX_FILTER + "marked");
+        assertEquals(new ListCustomerCommand(Customer.SORT_POINTS, Customer.FILTER_SHOW_MARKED), parsedCommand);
     }
 
     @Test

--- a/src/test/java/seedu/loyaltylift/logic/parser/ListCustomerCommandParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/ListCustomerCommandParserTest.java
@@ -1,8 +1,10 @@
 package seedu.loyaltylift.logic.parser;
 
+import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_FILTER;
 import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_SORT;
 import static seedu.loyaltylift.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.loyaltylift.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.loyaltylift.model.Model.PREDICATE_SHOW_ALL_CUSTOMERS;
 
 import org.junit.jupiter.api.Test;
 
@@ -17,15 +19,22 @@ public class ListCustomerCommandParserTest {
     public void parse_emptyArgs_success() {
         // sort by name
         ListCustomerCommand expectedListCustomerCommand =
-                new ListCustomerCommand(Customer.SORT_NAME);
+                new ListCustomerCommand(Customer.SORT_NAME, PREDICATE_SHOW_ALL_CUSTOMERS);
         assertParseSuccess(parser, "    ", expectedListCustomerCommand);
     }
 
     @Test
     public void parse_validSortOption_success() {
         ListCustomerCommand expectedListSortNameCustomerCommand =
-                new ListCustomerCommand(Customer.SORT_POINTS);
+                new ListCustomerCommand(Customer.SORT_POINTS, PREDICATE_SHOW_ALL_CUSTOMERS);
         assertParseSuccess(parser, " " + PREFIX_SORT + "points", expectedListSortNameCustomerCommand);
+    }
+
+    @Test
+    public void parser_validFilterOption_success() {
+        ListCustomerCommand expectedListFilterMarkedCustomerCommand =
+                new ListCustomerCommand(Customer.SORT_NAME, Customer.FILTER_SHOW_MARKED);
+        assertParseSuccess(parser, " " + PREFIX_FILTER + "marked", expectedListFilterMarkedCustomerCommand);
     }
 
     @Test


### PR DESCRIPTION
`listc` command is now operated in this way:

`listc [s/{name|points}] [f/marked]`

Examples:
* `listc` lists all customers sorted by name
* `listc s/points` lists all customers sorted by points
* `listc f/marked` lists all bookmarked customers. 