### PR TITLE
Filter customers by customer type

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -94,11 +94,12 @@ Examples:
 
 Shows a list of all customers.
 
-Format: `listc [s/{name|points}] [f/marked]`
+Format: `listc [s/{name|points}] [f/{marked|ind|ent}]`
 
 * Lists all customer with the specified sorting option.
 * Be default, customers are sorted by name
 * If `f/marked` is provided, then shows only bookmarked customers.
+* If `f/ind` or `f/ent` is provided, then shows only individual or enterprise customers respectively.
 
 Examples:
 * `listc` lists all customers sorted by name

--- a/src/main/java/seedu/loyaltylift/logic/commands/ListCustomerCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/ListCustomerCommand.java
@@ -18,10 +18,10 @@ public class ListCustomerCommand extends Command {
 
     public static final String COMMAND_WORD = "listc";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all customers with an optional sort option "
-            + "(name by default) and displays them as a list with index numbers.\n"
-            + "Parameters: [" + PREFIX_SORT + "{name|points}] + [" + PREFIX_FILTER + "STATUS\n"
-            + "Example: " + COMMAND_WORD + " s/points f/marked";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all customers with an optional sort "
+            + "(name by default) and filter option and displays them as a list with index numbers.\n"
+            + "Parameters: [" + PREFIX_SORT + "{name|points}] + [" + PREFIX_FILTER + "{marked|ind|ent}]\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_SORT + "points " + PREFIX_FILTER + "marked";
 
     public static final String MESSAGE_SUCCESS = "Listed all customers";
     public static final String MESSAGE_INVALID_SORT = "Unrecognized sort option";

--- a/src/main/java/seedu/loyaltylift/logic/commands/ListOrderCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/ListOrderCommand.java
@@ -18,10 +18,10 @@ public class ListOrderCommand extends Command {
 
     public static final String COMMAND_WORD = "listo";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all orders with an optional sort option "
-        + "(created date by default) and displays them as a list with index numbers.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all orders with an optional sort "
+        + "(created date by default) and filter option and displays them as a list with index numbers.\n"
         + "Parameters: [" + PREFIX_SORT + "{created|name|status}] + [" + PREFIX_FILTER + "STATUS]\n"
-        + "Example: " + COMMAND_WORD + " s/name f/pending";
+        + "Example: " + COMMAND_WORD + " " + PREFIX_SORT + "name " + PREFIX_FILTER + "pending";
 
     public static final String MESSAGE_SUCCESS = "Listed all orders";
     public static final String MESSAGE_INVALID_SORT = "Unrecognized sort option";

--- a/src/main/java/seedu/loyaltylift/logic/parser/ListOrderCommandParser.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/ListOrderCommandParser.java
@@ -11,8 +11,6 @@ import java.util.stream.Stream;
 import seedu.loyaltylift.logic.commands.ListOrderCommand;
 import seedu.loyaltylift.logic.parser.exceptions.ParseException;
 import seedu.loyaltylift.model.order.Order;
-import seedu.loyaltylift.model.order.OrderStatusPredicate;
-import seedu.loyaltylift.model.order.StatusValue;
 
 /**
  * Parses input arguments and creates a new ListOrderCommand object
@@ -34,8 +32,7 @@ public class ListOrderCommandParser implements Parser<ListOrderCommand> {
 
         Predicate<Order> predicate = PREDICATE_SHOW_ALL_ORDERS;
         if (arePrefixesPresent(argMultimap, PREFIX_FILTER)) {
-            StatusValue status = ParserUtil.parseStatusValue(argMultimap.getValue(PREFIX_FILTER).orElse(""));
-            predicate = new OrderStatusPredicate(status);
+            predicate = ParserUtil.parseOrderFilterOption(argMultimap.getValue(PREFIX_FILTER).orElse(""));
         }
 
         return new ListOrderCommand(comparator, predicate);

--- a/src/main/java/seedu/loyaltylift/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/ParserUtil.java
@@ -219,7 +219,7 @@ public class ParserUtil {
 
     /**
      * Parses a {@code String statusValue} into a {@code StatusValue}.
-     * @throws ParseException if the given {@code attribute} is invalid.
+     * @throws ParseException if the given {@code statusValue} is invalid.
      */
     public static StatusValue parseStatusValue(String statusValue) throws ParseException {
         requireNonNull(statusValue);
@@ -249,14 +249,17 @@ public class ParserUtil {
 
     /**
      * Parses a {@code String filterOption} into a {@code Predicate<Customer>}.
-     * @throws ParseException if the given {@code attribute} is invalid.
+     * @throws ParseException if the given {@code filterOption} is invalid.
      */
     public static Predicate<Customer> parseCustomerFilterOption(String filterOption) throws ParseException {
         requireNonNull(filterOption);
-        String trimmedAttribute = filterOption.trim();
-        switch (trimmedAttribute) {
-        case "marked":
+        String trimmedFilterOption = filterOption.trim().toUpperCase();
+        switch (trimmedFilterOption) {
+        case "MARKED":
             return Customer.FILTER_SHOW_MARKED;
+        case "IND":
+        case "ENT":
+            return new CustomerTypePredicate(parseCustomerType(trimmedFilterOption));
         default:
             throw new ParseException(ListCustomerCommand.MESSAGE_INVALID_FILTER);
         }

--- a/src/main/java/seedu/loyaltylift/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/ParserUtil.java
@@ -18,10 +18,12 @@ import seedu.loyaltylift.model.attribute.Name;
 import seedu.loyaltylift.model.attribute.Note;
 import seedu.loyaltylift.model.customer.Customer;
 import seedu.loyaltylift.model.customer.CustomerType;
+import seedu.loyaltylift.model.customer.CustomerTypePredicate;
 import seedu.loyaltylift.model.customer.Email;
 import seedu.loyaltylift.model.customer.Phone;
 import seedu.loyaltylift.model.customer.Points;
 import seedu.loyaltylift.model.order.Order;
+import seedu.loyaltylift.model.order.OrderStatusPredicate;
 import seedu.loyaltylift.model.order.Quantity;
 import seedu.loyaltylift.model.order.StatusValue;
 import seedu.loyaltylift.model.tag.Tag;
@@ -216,16 +218,29 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String sortOption} into a {@code Comparator<Customer>}.
+     * Parses a {@code String statusValue} into a {@code StatusValue}.
      * @throws ParseException if the given {@code attribute} is invalid.
+     */
+    public static StatusValue parseStatusValue(String statusValue) throws ParseException {
+        requireNonNull(statusValue);
+        try {
+            return StatusValue.fromString(statusValue.trim());
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(StatusValue.MESSAGE_FAIL_CONVERSION);
+        }
+    }
+
+    /**
+     * Parses a {@code String sortOption} into a {@code Comparator<Customer>}.
+     * @throws ParseException if the given {@code sortOption} is invalid.
      */
     public static Comparator<Customer> parseCustomerSortOption(String sortOption) throws ParseException {
         requireNonNull(sortOption);
-        String trimmedAttribute = sortOption.trim();
-        switch (trimmedAttribute) {
-        case "name":
+        String trimmedSortOption = sortOption.trim().toUpperCase();
+        switch (trimmedSortOption) {
+        case "NAME":
             return Customer.SORT_NAME;
-        case "points":
+        case "POINTS":
             return Customer.SORT_POINTS;
         default:
             throw new ParseException(ListCustomerCommand.MESSAGE_INVALID_SORT);
@@ -249,17 +264,17 @@ public class ParserUtil {
 
     /**
      * Parses a {@code String sortOption} into a {@code Comparator<Order>}.
-     * @throws ParseException if the given {@code attribute} is invalid.
+     * @throws ParseException if the given {@code sortOption} is invalid.
      */
     public static Comparator<Order> parseOrderSortOption(String sortOption) throws ParseException {
         requireNonNull(sortOption);
-        String trimmedAttribute = sortOption.trim();
-        switch (trimmedAttribute) {
-        case "created":
+        String trimmedSortOption = sortOption.trim().toUpperCase();
+        switch (trimmedSortOption) {
+        case "CREATED":
             return Order.SORT_CREATED_DATE;
-        case "name":
+        case "NAME":
             return Order.SORT_NAME;
-        case "status":
+        case "STATUS":
             return Order.SORT_STATUS;
         default:
             throw new ParseException(ListOrderCommand.MESSAGE_INVALID_SORT);
@@ -267,15 +282,18 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String statusValue} into a {@code StatusValue}.
-     * @throws ParseException if the given {@code attribute} is invalid.
+     * Parses a {@code String filterOption} into a {@code Predicate<Order>}.
+     * @throws ParseException if the given {@code filterOption} is invalid.
      */
-    public static StatusValue parseStatusValue(String statusValue) throws ParseException {
-        requireNonNull(statusValue);
+    public static Predicate<Order> parseOrderFilterOption(String filterOption) throws ParseException {
+        requireNonNull(filterOption);
+        String trimmedFilterOption = filterOption.trim();
         try {
-            return StatusValue.fromString(statusValue.trim());
-        } catch (IllegalArgumentException e) {
+            StatusValue status = parseStatusValue(trimmedFilterOption);
+            return new OrderStatusPredicate(status);
+        } catch (ParseException e) {
             throw new ParseException(ListOrderCommand.MESSAGE_INVALID_FILTER);
         }
     }
+
 }

--- a/src/main/java/seedu/loyaltylift/model/customer/CustomerTypePredicate.java
+++ b/src/main/java/seedu/loyaltylift/model/customer/CustomerTypePredicate.java
@@ -1,0 +1,27 @@
+package seedu.loyaltylift.model.customer;
+
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Customer}'s {@code CustomerType} matches the given type.
+ */
+public class CustomerTypePredicate implements Predicate<Customer> {
+    private final CustomerType customerType;
+
+    public CustomerTypePredicate(CustomerType customerType) {
+        this.customerType = customerType;
+    }
+
+    @Override
+    public boolean test(Customer customer) {
+        return customer.getCustomerType().equals(customerType);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof CustomerTypePredicate // instanceof handles nulls
+                && customerType.equals(((CustomerTypePredicate) other).customerType)); // state check
+    }
+
+}

--- a/src/test/java/seedu/loyaltylift/logic/commands/ListCustomerCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/ListCustomerCommandTest.java
@@ -15,6 +15,8 @@ import seedu.loyaltylift.model.Model;
 import seedu.loyaltylift.model.ModelManager;
 import seedu.loyaltylift.model.UserPrefs;
 import seedu.loyaltylift.model.customer.Customer;
+import seedu.loyaltylift.model.customer.CustomerType;
+import seedu.loyaltylift.model.customer.CustomerTypePredicate;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCustomerCommand.
@@ -33,17 +35,21 @@ public class ListCustomerCommandTest {
     @Test
     public void equals() {
         ListCustomerCommand listCommand = new ListCustomerCommand();
-        ListCustomerCommand listSortOrderCommand = new ListCustomerCommand(
+        ListCustomerCommand listSortPointsCommand = new ListCustomerCommand(
                 Customer.SORT_POINTS, PREDICATE_SHOW_ALL_CUSTOMERS);
-        ListCustomerCommand listFilterMarkedCommand = new ListCustomerCommand(
-                Customer.SORT_NAME, Customer.FILTER_SHOW_MARKED);
+        ListCustomerCommand listSortNameIndividualCommand = new ListCustomerCommand(
+                Customer.SORT_NAME, new CustomerTypePredicate(CustomerType.INDIVIDUAL));
 
         // same object -> returns true
         assertTrue(listCommand.equals(listCommand));
 
-        // same comparator -> returns true
+        // same comparator and predicate -> returns true
         ListCustomerCommand listCommandCopy = new ListCustomerCommand();
         assertTrue(listCommand.equals(listCommandCopy));
+
+        ListCustomerCommand listSortNameIndividualCommandCopy = new ListCustomerCommand(
+                Customer.SORT_NAME, new CustomerTypePredicate(CustomerType.INDIVIDUAL));
+        assertTrue(listSortNameIndividualCommand.equals(listSortNameIndividualCommandCopy));
 
         // different types -> returns false
         assertFalse(listCommand.equals(1));
@@ -52,10 +58,10 @@ public class ListCustomerCommandTest {
         assertFalse(listCommand.equals(null));
 
         // different comparator -> returns false
-        assertFalse(listCommand.equals(listSortOrderCommand));
+        assertFalse(listCommand.equals(listSortPointsCommand));
 
         // different predicate -> returns false
-        assertFalse(listCommand.equals(listFilterMarkedCommand));
+        assertFalse(listCommand.equals(listSortNameIndividualCommand));
     }
 
     @Test

--- a/src/test/java/seedu/loyaltylift/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/AddressBookParserTest.java
@@ -108,17 +108,21 @@ public class AddressBookParserTest {
     public void parseCommand_listc() throws Exception {
         ListCustomerCommand parsedCommand;
 
+        // no args
         parsedCommand = (ListCustomerCommand) parser.parseCommand(ListCustomerCommand.COMMAND_WORD);
-        assertEquals(new ListCustomerCommand(Customer.SORT_NAME, PREDICATE_SHOW_ALL_CUSTOMERS), parsedCommand);
+        assertEquals(new ListCustomerCommand(), parsedCommand);
 
+        // sort points
         parsedCommand = (ListCustomerCommand) parser.parseCommand(
                 ListCustomerCommand.COMMAND_WORD + " " + PREFIX_SORT + "points");
         assertEquals(new ListCustomerCommand(Customer.SORT_POINTS, PREDICATE_SHOW_ALL_CUSTOMERS), parsedCommand);
 
+        // filter marked
         parsedCommand = (ListCustomerCommand) parser.parseCommand(
                 ListCustomerCommand.COMMAND_WORD + " " + PREFIX_FILTER + "marked");
         assertEquals(new ListCustomerCommand(Customer.SORT_NAME, Customer.FILTER_SHOW_MARKED), parsedCommand);
 
+        // sort points and filter marked
         parsedCommand = (ListCustomerCommand) parser.parseCommand(ListCustomerCommand.COMMAND_WORD + " "
                 + PREFIX_SORT + "points" + " " + PREFIX_FILTER + "marked");
         assertEquals(new ListCustomerCommand(Customer.SORT_POINTS, Customer.FILTER_SHOW_MARKED), parsedCommand);

--- a/src/test/java/seedu/loyaltylift/logic/parser/ListCustomerCommandParserTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/parser/ListCustomerCommandParserTest.java
@@ -18,8 +18,7 @@ public class ListCustomerCommandParserTest {
     @Test
     public void parse_emptyArgs_success() {
         // sort by name
-        ListCustomerCommand expectedListCustomerCommand =
-                new ListCustomerCommand(Customer.SORT_NAME, PREDICATE_SHOW_ALL_CUSTOMERS);
+        ListCustomerCommand expectedListCustomerCommand = new ListCustomerCommand();
         assertParseSuccess(parser, "    ", expectedListCustomerCommand);
     }
 
@@ -40,6 +39,8 @@ public class ListCustomerCommandParserTest {
     @Test
     public void parse_invalidSortOption_failure() {
         assertParseFailure(parser, " " + PREFIX_SORT + "invalid", ListCustomerCommand.MESSAGE_INVALID_SORT);
+
+        assertParseFailure(parser, " " + PREFIX_FILTER + "invalid", ListCustomerCommand.MESSAGE_INVALID_FILTER);
     }
 
 }


### PR DESCRIPTION
Adds `ind` and `ent` filter options to `listc`

```
listc [s/{name|points}] [f/{marked|ind|ent}]
```

Closes #96