### PR TITLE
Fix list commands not switching tabs

### DIFF
--- a/src/main/java/seedu/loyaltylift/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/CommandResult.java
@@ -23,24 +23,61 @@ public class CommandResult {
     /** The application should select & view a specific order */
     private final Integer orderIndex;
 
-    /**
-     * Constructs a {@code CommandResult} with the specified fields.
-     */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit,
-                         Integer customerIndex, Integer orderIndex) {
-        this.feedbackToUser = requireNonNull(feedbackToUser);
-        this.showHelp = showHelp;
-        this.exit = exit;
-        this.customerIndex = customerIndex;
-        this.orderIndex = orderIndex;
-    }
+    /** The application should show the customer list */
+    private final boolean showCustomerSelection;
+
+    /** The application should show the order list */
+    private final boolean showOrderSelection;
 
     /**
      * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false, null, null);
+        this(feedbackToUser, false, false, false, false, null, null);
+    }
+
+    /**
+     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
+     * {@code showHelp}, and {@code exit}, and other fields set to their default value.
+     */
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
+        this(feedbackToUser, showHelp, exit, false, false, null, null);
+    }
+
+    /**
+     * Constructs a {@code CommandResult} to show the customer/order list.
+     */
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit,
+                         boolean showCustomerSelection, boolean showOrderSelection) {
+        this(requireNonNull(feedbackToUser), showHelp, exit,
+                showCustomerSelection, showOrderSelection,
+                null, null);
+    }
+
+    /**
+     * Constructs a {@code CommandResult} show a specific customer/order index.
+     */
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit,
+                         Integer customerIndex, Integer orderIndex) {
+        this(requireNonNull(feedbackToUser), showHelp, exit,
+                false, false,
+                customerIndex, orderIndex);
+    }
+
+    /**
+     * Private constructor for a {@code CommandResult} with all fields.
+     */
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit,
+                         boolean showCustomerSelection, boolean showOrderSelection,
+                         Integer customerIndex, Integer orderIndex) {
+        this.feedbackToUser = requireNonNull(feedbackToUser);
+        this.showHelp = showHelp;
+        this.exit = exit;
+        this.customerIndex = customerIndex;
+        this.orderIndex = orderIndex;
+        this.showCustomerSelection = showCustomerSelection;
+        this.showOrderSelection = showOrderSelection;
     }
 
     public String getFeedbackToUser() {
@@ -63,6 +100,22 @@ public class CommandResult {
         return orderIndex;
     }
 
+    /**
+     * Returns {@code true} if the customer index is set.
+     * @return {@code true} if the customer index is set.
+     */
+    public boolean hasCustomerIndex() {
+        return customerIndex != null;
+    }
+
+    /**
+     * Returns {@code false} if the order index is set.
+     * @return {@code false} if the order index is set.
+     */
+    public boolean hasOrderIndex() {
+        return orderIndex != null;
+    }
+
     public boolean isShowHelp() {
         return showHelp;
     }
@@ -72,11 +125,11 @@ public class CommandResult {
     }
 
     public boolean isShowCustomerSelection() {
-        return customerIndex != null;
+        return showCustomerSelection || hasCustomerIndex();
     }
 
     public boolean isShowOrderSelection() {
-        return orderIndex != null;
+        return showOrderSelection || hasOrderIndex();
     }
 
     @Override
@@ -95,7 +148,9 @@ public class CommandResult {
                 && showHelp == otherCommandResult.showHelp
                 && exit == otherCommandResult.exit
                 && Objects.equals(customerIndex, otherCommandResult.customerIndex)
-                && Objects.equals(orderIndex, otherCommandResult.orderIndex);
+                && Objects.equals(orderIndex, otherCommandResult.orderIndex)
+                && Objects.equals(showCustomerSelection, otherCommandResult.showCustomerSelection)
+                && Objects.equals(showOrderSelection, otherCommandResult.showOrderSelection);
     }
 
     @Override

--- a/src/main/java/seedu/loyaltylift/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/ExitCommand.java
@@ -13,7 +13,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, null, null);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false, false);
     }
 
 }

--- a/src/main/java/seedu/loyaltylift/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/HelpCommand.java
@@ -16,6 +16,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, null, null);
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, false, false);
     }
 }

--- a/src/main/java/seedu/loyaltylift/logic/commands/ListCustomerCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/ListCustomerCommand.java
@@ -50,7 +50,8 @@ public class ListCustomerCommand extends Command {
         requireNonNull(model);
         model.sortFilteredCustomerList(comparator);
         model.updateFilteredCustomerList(predicate);
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(MESSAGE_SUCCESS, false, false,
+                true, false);
     }
 
     @Override

--- a/src/main/java/seedu/loyaltylift/logic/commands/ListOrderCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/ListOrderCommand.java
@@ -50,7 +50,8 @@ public class ListOrderCommand extends Command {
         requireNonNull(model);
         model.sortFilteredOrderList(comparator);
         model.updateFilteredOrderList(predicate);
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(MESSAGE_SUCCESS, false, false,
+                false, true);
     }
 
     @Override

--- a/src/main/java/seedu/loyaltylift/ui/MainWindow.java
+++ b/src/main/java/seedu/loyaltylift/ui/MainWindow.java
@@ -244,11 +244,17 @@ public class MainWindow extends UiPart<Stage> {
 
             if (commandResult.isShowCustomerSelection()) {
                 tableTabPane.getSelectionModel().select(customerTab);
-                customerListPanel.getSelectionModel().select(commandResult.getCustomerIndex());
             }
 
             if (commandResult.isShowOrderSelection()) {
                 tableTabPane.getSelectionModel().select(orderTab);
+            }
+
+            if (commandResult.hasCustomerIndex()) {
+                customerListPanel.getSelectionModel().select(commandResult.getCustomerIndex());
+            }
+
+            if (commandResult.hasOrderIndex()) {
                 orderListPanel.getSelectionModel().select(commandResult.getOrderIndex());
             }
 

--- a/src/main/resources/view/Badge.fxml
+++ b/src/main/resources/view/Badge.fxml
@@ -4,7 +4,7 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.StackPane?>
 
-<StackPane fx:id="base" styleClass="badge" stylesheets="@Badge.css" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<StackPane fx:id="base" styleClass="badge" stylesheets="@Badge.css" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <Label fx:id="tag" text="\$tag" />
    </children>

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -3,6 +3,6 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.StackPane?>
 
-<StackPane stylesheets="@CommandBox.css" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<StackPane stylesheets="@CommandBox.css" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
   <TextField id="commandTextField" fx:id="commandTextField" onAction="#handleCommandEntered" prefHeight="50.0" promptText="Enter command here..." stylesheets="@CommandBox.css" />
 </StackPane>

--- a/src/main/resources/view/Customer/CustomerGeneralInfo.fxml
+++ b/src/main/resources/view/Customer/CustomerGeneralInfo.fxml
@@ -7,7 +7,7 @@
 <?import javafx.scene.layout.VBox?>
 
 
-<VBox spacing="5.0" styleClass="base" stylesheets="@CustomerSection.css" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<VBox spacing="5.0" styleClass="base" stylesheets="@CustomerSection.css" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <HBox alignment="CENTER_LEFT" spacing="4.0">
          <children>

--- a/src/main/resources/view/Customer/CustomerInfo.fxml
+++ b/src/main/resources/view/Customer/CustomerInfo.fxml
@@ -8,7 +8,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<ScrollPane cacheShape="false" fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER" minHeight="100.0" minWidth="300.0" stylesheets="@CustomerInfo.css" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<ScrollPane cacheShape="false" fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER" minHeight="100.0" minWidth="300.0" stylesheets="@CustomerInfo.css" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
    <content>
       <VBox fx:id="verticalContainer" spacing="10.0">
          <children>

--- a/src/main/resources/view/Customer/CustomerOrderCard.fxml
+++ b/src/main/resources/view/Customer/CustomerOrderCard.fxml
@@ -14,7 +14,7 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" stylesheets="@CustomerOrderCard.css" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" stylesheets="@CustomerOrderCard.css" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
    <cursor>
       <Cursor fx:constant="DEFAULT" />
    </cursor>

--- a/src/main/resources/view/Customer/CustomerOrderListPanel.fxml
+++ b/src/main/resources/view/Customer/CustomerOrderListPanel.fxml
@@ -4,7 +4,7 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox styleClass="base" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<VBox styleClass="base" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <ListView fx:id="orderListView" styleClass="orderListView" />
    </children>

--- a/src/main/resources/view/CustomerListCard.fxml
+++ b/src/main/resources/view/CustomerListCard.fxml
@@ -6,7 +6,7 @@
 <?import javafx.scene.image.*?>
 <?import javafx.scene.layout.*?>
 
-<HBox id="cardPane" fx:id="cardPane" stylesheets="@CustomerListCard.css" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" stylesheets="@CustomerListCard.css" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />

--- a/src/main/resources/view/CustomerListPanel.fxml
+++ b/src/main/resources/view/CustomerListPanel.fxml
@@ -3,6 +3,6 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<VBox xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
   <ListView id="customerListView" fx:id="customerListView" style="-fx-padding: 0; -fx-background-insets: 0;" stylesheets="@CustomerListPanel.css" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/main/resources/view/Order/OrderGeneralInfo.fxml
+++ b/src/main/resources/view/Order/OrderGeneralInfo.fxml
@@ -6,7 +6,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox spacing="5.0" styleClass="base" stylesheets="@OrderGeneralInfo.css" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<VBox spacing="5.0" styleClass="base" stylesheets="@OrderGeneralInfo.css" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <HBox alignment="CENTER_LEFT" spacing="4.0">
          <children>

--- a/src/main/resources/view/Order/OrderHistoryPanel.fxml
+++ b/src/main/resources/view/Order/OrderHistoryPanel.fxml
@@ -4,7 +4,7 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox styleClass="base" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<VBox styleClass="base" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <ListView fx:id="orderHistoryListView" styleClass="orderHistoryListView" />
    </children>

--- a/src/main/resources/view/Order/OrderInfo.fxml
+++ b/src/main/resources/view/Order/OrderInfo.fxml
@@ -8,7 +8,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<ScrollPane cacheShape="false" fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER" minHeight="100.0" minWidth="300.0" stylesheets="@OrderInfo.css" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<ScrollPane cacheShape="false" fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER" minHeight="100.0" minWidth="300.0" stylesheets="@OrderInfo.css" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
    <content>
       <VBox fx:id="verticalContainer" spacing="10.0">
          <children>

--- a/src/main/resources/view/OrderListCard.fxml
+++ b/src/main/resources/view/OrderListCard.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" stylesheets="@OrderListCard.css" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" stylesheets="@OrderListCard.css" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />

--- a/src/main/resources/view/OrderListPanel.fxml
+++ b/src/main/resources/view/OrderListPanel.fxml
@@ -3,6 +3,6 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<VBox xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
   <ListView id="orderListView" fx:id="orderListView" style="-fx-padding: 0; -fx-background-insets: 0;" stylesheets="@OrderListPanel.css" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -3,6 +3,6 @@
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.StackPane?>
 
-<StackPane fx:id="placeHolder" styleClass="pane" stylesheets="@ResultDisplay.css" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<StackPane fx:id="placeHolder" styleClass="pane" stylesheets="@ResultDisplay.css" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
   <TextArea id="resultDisplay" fx:id="resultDisplay" editable="false" prefHeight="100.0" styleClass="result-display" stylesheets="@ResultDisplay.css" />
 </StackPane>

--- a/src/test/java/seedu/loyaltylift/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/CommandResultTest.java
@@ -15,7 +15,7 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, null, null)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", false, false)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -30,10 +30,22 @@ public class CommandResultTest {
         assertFalse(commandResult.equals(new CommandResult("different")));
 
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, null, null)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", true, false)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, null, null)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true)));
+
+        // different showCustomerSelection value -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, true, false)));
+
+        // different showOrderSelection value -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false, true)));
+
+        // different customer index -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, 0, null)));
+
+        // different order index -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, null, 0)));
     }
 
     @Test
@@ -42,7 +54,7 @@ public class CommandResultTest {
         CommandResult commandResult = new CommandResult("feedback", false, false, index, null);
         assertEquals(commandResult.getCustomerIndex(), index);
 
-        CommandResult nullCommandResult = new CommandResult("feedback", false, false, null, null);
+        CommandResult nullCommandResult = new CommandResult("feedback", false, false);
         assertNull(nullCommandResult.getCustomerIndex());
 
         CommandResult alsoNullCommandResult = new CommandResult("feedback");
@@ -67,10 +79,16 @@ public class CommandResultTest {
         CommandResult falseCommandResult = new CommandResult("feedback");
         assertFalse(falseCommandResult.isShowCustomerSelection());
 
-        CommandResult secondFalseCommandResult = new CommandResult("feedback", true, true, null, null);
-        assertFalse(secondFalseCommandResult.isShowCustomerSelection());
+        falseCommandResult = new CommandResult("feedback", true, true, false, true);
+        assertFalse(falseCommandResult.isShowCustomerSelection());
 
-        CommandResult trueCommandResult = new CommandResult("feedback", true, true, 0, null);
+        falseCommandResult = new CommandResult("feedback", true, true, null, null);
+        assertFalse(falseCommandResult.isShowCustomerSelection());
+
+        CommandResult trueCommandResult = new CommandResult("feedback", true, true, true, false);
+        assertTrue(trueCommandResult.isShowCustomerSelection());
+
+        trueCommandResult = new CommandResult("feedback", true, true, 0, null);
         assertTrue(trueCommandResult.isShowCustomerSelection());
     }
 
@@ -79,10 +97,16 @@ public class CommandResultTest {
         CommandResult falseCommandResult = new CommandResult("feedback");
         assertFalse(falseCommandResult.isShowOrderSelection());
 
-        CommandResult secondFalseCommandResult = new CommandResult("feedback", true, true, null, null);
-        assertFalse(secondFalseCommandResult.isShowOrderSelection());
+        falseCommandResult = new CommandResult("feedback", true, true, true, false);
+        assertFalse(falseCommandResult.isShowOrderSelection());
+
+        falseCommandResult = new CommandResult("feedback", true, true, 0, null);
+        assertFalse(falseCommandResult.isShowOrderSelection());
 
         CommandResult trueCommandResult = new CommandResult("feedback", true, true, null, 0);
+        assertTrue(trueCommandResult.isShowOrderSelection());
+
+        trueCommandResult = new CommandResult("feedback", true, true, false, true);
         assertTrue(trueCommandResult.isShowOrderSelection());
     }
 
@@ -97,10 +121,10 @@ public class CommandResultTest {
 
     @Test
     public void exit() {
-        CommandResult trueCommandResult = new CommandResult("feedback", false, true, null, null);
+        CommandResult trueCommandResult = new CommandResult("feedback", false, true);
         assertTrue(trueCommandResult.isExit());
 
-        CommandResult falseCommandResult = new CommandResult("feedback", false, false, null, null);
+        CommandResult falseCommandResult = new CommandResult("feedback", false, false);
         assertFalse(falseCommandResult.isExit());
     }
 
@@ -115,9 +139,21 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false, null, null).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, null, null).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true).hashCode());
+
+        // different showCustomerSelection value -> returns different hashcode
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, true, false).hashCode());
+
+        // different showOrderSelection value -> returns different hashcode
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, false, true).hashCode());
+
+        // different customer index -> returns different hashcode
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, 0, null).hashCode());
+
+        // different order index -> returns different hashcode
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, null, 0).hashCode());
     }
 }

--- a/src/test/java/seedu/loyaltylift/logic/commands/ListCustomerCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/ListCustomerCommandTest.java
@@ -66,12 +66,16 @@ public class ListCustomerCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCustomerCommand(), model, ListCustomerCommand.MESSAGE_SUCCESS, expectedModel);
+        CommandResult expectedCommandResult = new CommandResult(
+                ListCustomerCommand.MESSAGE_SUCCESS, false, false, true, false);
+        assertCommandSuccess(new ListCustomerCommand(), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showCustomerAtIndex(model, INDEX_FIRST);
-        assertCommandSuccess(new ListCustomerCommand(), model, ListCustomerCommand.MESSAGE_SUCCESS, expectedModel);
+        CommandResult expectedCommandResult = new CommandResult(
+                ListCustomerCommand.MESSAGE_SUCCESS, false, false, true, false);
+        assertCommandSuccess(new ListCustomerCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/loyaltylift/logic/commands/ListOrderCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/ListOrderCommandTest.java
@@ -66,12 +66,16 @@ public class ListOrderCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListOrderCommand(), model, ListOrderCommand.MESSAGE_SUCCESS, expectedModel);
+        CommandResult expectedCommandResult = new CommandResult(
+                ListOrderCommand.MESSAGE_SUCCESS, false, false, false, true);
+        assertCommandSuccess(new ListOrderCommand(), model, expectedCommandResult, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showOrderAtIndex(model, INDEX_FIRST);
-        assertCommandSuccess(new ListOrderCommand(), model, ListOrderCommand.MESSAGE_SUCCESS, expectedModel);
+        CommandResult expectedCommandResult = new CommandResult(
+                ListOrderCommand.MESSAGE_SUCCESS, false, false, false, true);
+        assertCommandSuccess(new ListOrderCommand(), model, expectedCommandResult, expectedModel);
     }
 }


### PR DESCRIPTION
Previously the tabs are only switched when viewing a specific customer/order.

I added two fields to `CommandResult`: `showCustomerSelection` and `showOrderSelection` for the list commands.

[REVIEW #98 FIRST]