### PR TITLE
Multiple fixes made

### DIFF
--- a/src/main/java/seedu/loyaltylift/logic/commands/MarkCustomerCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/MarkCustomerCommand.java
@@ -1,7 +1,6 @@
 package seedu.loyaltylift.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.loyaltylift.model.Model.PREDICATE_SHOW_ALL_CUSTOMERS;
 
 import java.util.List;
 import java.util.Set;
@@ -56,7 +55,6 @@ public class MarkCustomerCommand extends Command {
         Customer customerToMark = lastShownList.get(index.getZeroBased());
         Customer markedCustomer = createMarkedCustomer(customerToMark);
         model.setCustomer(customerToMark, markedCustomer);
-        model.updateFilteredCustomerList(PREDICATE_SHOW_ALL_CUSTOMERS);
         return new CommandResult(String.format(MESSAGE_MARK_CUSTOMER_SUCCESS, markedCustomer));
     }
 

--- a/src/main/java/seedu/loyaltylift/logic/commands/UnmarkCustomerCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/UnmarkCustomerCommand.java
@@ -1,7 +1,6 @@
 package seedu.loyaltylift.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.loyaltylift.model.Model.PREDICATE_SHOW_ALL_CUSTOMERS;
 
 import java.util.List;
 import java.util.Set;
@@ -55,7 +54,6 @@ public class UnmarkCustomerCommand extends Command {
         Customer customerToUnmark = lastShownList.get(index.getZeroBased());
         Customer unmarkedCustomer = createUnmarkedCustomer(customerToUnmark);
         model.setCustomer(customerToUnmark, unmarkedCustomer);
-        model.updateFilteredCustomerList(PREDICATE_SHOW_ALL_CUSTOMERS);
         return new CommandResult(String.format(MESSAGE_UNMARK_CUSTOMER_SUCCESS, unmarkedCustomer));
     }
 

--- a/src/main/java/seedu/loyaltylift/storage/JsonAdaptedOrder.java
+++ b/src/main/java/seedu/loyaltylift/storage/JsonAdaptedOrder.java
@@ -15,6 +15,7 @@ import seedu.loyaltylift.model.attribute.Address;
 import seedu.loyaltylift.model.attribute.Name;
 import seedu.loyaltylift.model.attribute.Note;
 import seedu.loyaltylift.model.customer.Customer;
+import seedu.loyaltylift.model.customer.exceptions.CustomerNotFoundException;
 import seedu.loyaltylift.model.order.CreatedDate;
 import seedu.loyaltylift.model.order.Order;
 import seedu.loyaltylift.model.order.Quantity;
@@ -28,6 +29,7 @@ public class JsonAdaptedOrder {
 
     public static final String CUSTOMER_ID_MESSAGE_FIELD = "Customer ID";
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Order's %s field is missing!";
+    public static final String NOT_FOUND_FIELD_MESSAGE_FORMAT = "Order's %s cannot be found!";
 
     private final String customerId;
     private final String name;
@@ -83,7 +85,13 @@ public class JsonAdaptedOrder {
         if (customerId == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, CUSTOMER_ID_MESSAGE_FIELD));
         }
-        Customer customer = addressBook.getCustomer(customerId);
+        Customer customer;
+//        Customer customer = addressBook.getCustomer(customerId);
+        try {
+            customer = addressBook.getCustomer(customerId);
+        } catch (CustomerNotFoundException e) {
+            throw new IllegalValueException(String.format(NOT_FOUND_FIELD_MESSAGE_FORMAT, CUSTOMER_ID_MESSAGE_FIELD));
+        }
 
         if (name == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));

--- a/src/main/java/seedu/loyaltylift/storage/JsonAdaptedOrder.java
+++ b/src/main/java/seedu/loyaltylift/storage/JsonAdaptedOrder.java
@@ -86,7 +86,6 @@ public class JsonAdaptedOrder {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, CUSTOMER_ID_MESSAGE_FIELD));
         }
         Customer customer;
-//        Customer customer = addressBook.getCustomer(customerId);
         try {
             customer = addressBook.getCustomer(customerId);
         } catch (CustomerNotFoundException e) {

--- a/src/test/java/seedu/loyaltylift/logic/commands/MarkCustomerCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/MarkCustomerCommandTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.loyaltylift.commons.core.Messages;
 import seedu.loyaltylift.commons.core.index.Index;
+import seedu.loyaltylift.model.AddressBook;
 import seedu.loyaltylift.model.Model;
 import seedu.loyaltylift.model.ModelManager;
 import seedu.loyaltylift.model.UserPrefs;
@@ -69,7 +70,7 @@ public class MarkCustomerCommandTest {
 
     @Test
     public void execute_validIndexFilteredList_success() {
-        showCustomerAtIndex(model, INDEX_FIRST);
+        model.sortFilteredCustomerList(Customer.SORT_POINTS);
 
         Customer customerToMark = model.getFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
         CustomerType customerType = customerToMark.getCustomerType();
@@ -86,7 +87,7 @@ public class MarkCustomerCommandTest {
 
         String expectedMessage = String.format(MarkCustomerCommand.MESSAGE_MARK_CUSTOMER_SUCCESS, markedCustomer);
 
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setCustomer(model.getFilteredCustomerList().get(0), markedCustomer);
 
         assertCommandSuccess(markCustomerCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/loyaltylift/logic/commands/UnmarkCustomerCommandTest.java
+++ b/src/test/java/seedu/loyaltylift/logic/commands/UnmarkCustomerCommandTest.java
@@ -69,7 +69,7 @@ public class UnmarkCustomerCommandTest {
 
     @Test
     public void execute_validIndexFilteredList_success() {
-        showCustomerAtIndex(model, INDEX_FIRST);
+        model.sortFilteredCustomerList(Customer.SORT_POINTS);
 
         Customer customerToUnmark = model.getFilteredCustomerList().get(INDEX_FIRST.getZeroBased());
         CustomerType customerType = customerToUnmark.getCustomerType();

--- a/src/test/java/seedu/loyaltylift/storage/JsonAdaptedOrderTest.java
+++ b/src/test/java/seedu/loyaltylift/storage/JsonAdaptedOrderTest.java
@@ -3,6 +3,7 @@ package seedu.loyaltylift.storage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.loyaltylift.storage.JsonAdaptedOrder.CUSTOMER_ID_MESSAGE_FIELD;
 import static seedu.loyaltylift.storage.JsonAdaptedOrder.MISSING_FIELD_MESSAGE_FORMAT;
+import static seedu.loyaltylift.storage.JsonAdaptedOrder.NOT_FOUND_FIELD_MESSAGE_FORMAT;
 import static seedu.loyaltylift.testutil.Assert.assertThrows;
 import static seedu.loyaltylift.testutil.TypicalOrders.ORDER_A;
 
@@ -36,6 +37,7 @@ public class JsonAdaptedOrderTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_CREATED_DATE = "2020-05-02";
 
+    private static final String ABSENT_CUSTOMER_UID = "Ashley Porter";
     private static final String VALID_CUSTOMER_UID = ORDER_A.getCustomer().getUid();
     private static final String VALID_NAME = ORDER_A.getName().fullName;
     private static final Integer VALID_QUANTITY = ORDER_A.getQuantity().value;
@@ -64,6 +66,15 @@ public class JsonAdaptedOrderTest {
                 null, VALID_NAME, VALID_QUANTITY, VALID_STATUS, VALID_ADDRESS,
                 VALID_CREATED_DATE, VALID_NOTE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, CUSTOMER_ID_MESSAGE_FIELD);
+        assertThrows(IllegalValueException.class, expectedMessage, () -> order.toModelType(ADDRESS_BOOK));
+    }
+
+    @Test
+    public void toModelType_absentCustomerAssociation_throwsIllegalValueException() {
+        JsonAdaptedOrder order = new JsonAdaptedOrder(
+                ABSENT_CUSTOMER_UID, VALID_NAME, VALID_QUANTITY, VALID_STATUS, VALID_ADDRESS,
+                VALID_CREATED_DATE, VALID_NOTE);
+        String expectedMessage = String.format(NOT_FOUND_FIELD_MESSAGE_FORMAT, CUSTOMER_ID_MESSAGE_FIELD);
         assertThrows(IllegalValueException.class, expectedMessage, () -> order.toModelType(ADDRESS_BOOK));
     }
 

--- a/src/test/java/seedu/loyaltylift/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/loyaltylift/storage/JsonSerializableAddressBookTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import seedu.loyaltylift.commons.exceptions.IllegalValueException;
 import seedu.loyaltylift.commons.util.JsonUtil;
 import seedu.loyaltylift.model.AddressBook;
-import seedu.loyaltylift.model.customer.exceptions.CustomerNotFoundException;
 import seedu.loyaltylift.testutil.TypicalAddressBook;
 
 public class JsonSerializableAddressBookTest {
@@ -50,7 +49,7 @@ public class JsonSerializableAddressBookTest {
     public void toModelType_noSuchCustomer_throwsIllegalValueException() throws Exception {
         JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(CUSTOMER_NOT_FOUND_FILE,
                 JsonSerializableAddressBook.class).get();
-        assertThrows(CustomerNotFoundException.class, dataFromFile::toModelType);
+        assertThrows(IllegalValueException.class, dataFromFile::toModelType);
     }
 
 }


### PR DESCRIPTION
1. #137 Fixed bug where an inconsistency in storage json causes LoyaltyLift to fail to start up.
2. #149 Fixed bug where execution of markc and unmarkc causes list view to reset to default.
3. #150 Fixed typo in JsonSerializableAddressBookTest.java: it will check that `IllegalValueException` is thrown.