### PR TITLE
fix: Fix editing order quantity or adding duplicate order

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -499,6 +499,10 @@ Examples:
 * `addo 4 n/Strawberry ice cream`
   * Adds the order 1 x Strawberry ice cream, tags it to customer 4, and sets status to "pending", address is the customer's address.
 
+<div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
+Currently, you are unable to add the same order name and quantity for the same customer twice in the same day!
+</div>
+
 #### Listing all customers : `listo`
 
 Shows a list of all orders, with an optional filter and sort option.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -500,7 +500,7 @@ Examples:
   * Adds the order 1 x Strawberry ice cream, tags it to customer 4, and sets status to "pending", address is the customer's address.
 
 <div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
-Currently, you are unable to add the same order name and quantity for the same customer twice in the same day!
+Currently, you are unable to add the same order name and quantity for the same customer twice on the same day!
 </div>
 
 #### Listing all customers : `listo`

--- a/src/main/java/seedu/loyaltylift/logic/commands/AddOrderCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/AddOrderCommand.java
@@ -34,6 +34,7 @@ public class AddOrderCommand extends Command {
             + "[" + PREFIX_ADDRESS + "ADDRESS]";
 
     public static final String MESSAGE_SUCCESS = "New order added: \n%1$s";
+    public static final String MESSAGE_DUPLICATE_ORDER = "This order already exists for the customer today";
 
     private final Index customerIndex;
     private final AddOrderDescriptor addOrderDescriptor;
@@ -60,6 +61,10 @@ public class AddOrderCommand extends Command {
 
         Customer taggedCustomer = lastShownList.get(customerIndex.getZeroBased());
         Order createdOrder = createOrder(taggedCustomer, addOrderDescriptor);
+
+        if (model.hasOrder(createdOrder)) {
+            throw new CommandException(MESSAGE_DUPLICATE_ORDER);
+        }
 
         model.addOrder(createdOrder);
         model.updateFilteredOrderList(PREDICATE_SHOW_ALL_ORDERS);

--- a/src/main/java/seedu/loyaltylift/logic/commands/EditOrderCommand.java
+++ b/src/main/java/seedu/loyaltylift/logic/commands/EditOrderCommand.java
@@ -45,6 +45,7 @@ public class EditOrderCommand extends Command {
 
     public static final String MESSAGE_EDIT_ORDER_SUCCESS = "Edited Order: \n%1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_ORDER = "This order already exists for the customer today";
 
     private final Index index;
     private final EditOrderDescriptor editOrderDescriptor;
@@ -72,6 +73,10 @@ public class EditOrderCommand extends Command {
 
         Order orderToEdit = lastShownList.get(index.getZeroBased());
         Order editedOrder = createEditedOrder(orderToEdit, editOrderDescriptor);
+
+        if (!orderToEdit.isSameOrder(editedOrder) && model.hasOrder(editedOrder)) {
+            throw new CommandException(MESSAGE_DUPLICATE_ORDER);
+        }
 
         model.setOrder(orderToEdit, editedOrder);
         model.updateFilteredOrderList(PREDICATE_SHOW_ALL_ORDERS);

--- a/src/main/java/seedu/loyaltylift/logic/parser/EditOrderCommandParser.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/EditOrderCommandParser.java
@@ -41,7 +41,7 @@ public class EditOrderCommandParser implements Parser<EditOrderCommand> {
             editOrderDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }
         if (argMultimap.getValue(PREFIX_QUANTITY).isPresent()) {
-            editOrderDescriptor.setQuantity(ParserUtil.parseQuantity(argMultimap.getValue(PREFIX_PHONE).get()));
+            editOrderDescriptor.setQuantity(ParserUtil.parseQuantity(argMultimap.getValue(PREFIX_QUANTITY).get()));
         }
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
             editOrderDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));

--- a/src/main/java/seedu/loyaltylift/logic/parser/EditOrderCommandParser.java
+++ b/src/main/java/seedu/loyaltylift/logic/parser/EditOrderCommandParser.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.loyaltylift.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.loyaltylift.logic.parser.CliSyntax.PREFIX_QUANTITY;
 
 import seedu.loyaltylift.commons.core.index.Index;

--- a/src/main/java/seedu/loyaltylift/model/order/Order.java
+++ b/src/main/java/seedu/loyaltylift/model/order/Order.java
@@ -146,11 +146,18 @@ public class Order {
 
 
     /**
-     * Returns true if both orders have the same name.
+     * Returns true if both orders belongs to the same customer and have the same name and quantity.
      * This defines a weaker notion of equality between two orders.
      */
     public boolean isSameOrder(Order otherOrder) {
-        return equals(otherOrder);
+        if (otherOrder == this) {
+            return true;
+        }
+
+        return otherOrder != null
+                && otherOrder.getCustomer().equals(getCustomer())
+                && otherOrder.getName().equals(getName())
+                && otherOrder.getQuantity().equals(getQuantity());
     }
 
     /**

--- a/src/main/java/seedu/loyaltylift/model/order/Order.java
+++ b/src/main/java/seedu/loyaltylift/model/order/Order.java
@@ -146,7 +146,8 @@ public class Order {
 
 
     /**
-     * Returns true if both orders belongs to the same customer and have the same name and quantity.
+     * Returns true if both orders belongs to the same customer and have the same name and quantity,
+     * on the same day.
      * This defines a weaker notion of equality between two orders.
      */
     public boolean isSameOrder(Order otherOrder) {
@@ -157,7 +158,8 @@ public class Order {
         return otherOrder != null
                 && otherOrder.getCustomer().equals(getCustomer())
                 && otherOrder.getName().equals(getName())
-                && otherOrder.getQuantity().equals(getQuantity());
+                && otherOrder.getQuantity().equals(getQuantity())
+                && otherOrder.getCreatedDate().equals(getCreatedDate());
     }
 
     /**

--- a/src/test/java/seedu/loyaltylift/model/order/OrderTest.java
+++ b/src/test/java/seedu/loyaltylift/model/order/OrderTest.java
@@ -8,6 +8,7 @@ import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_NAME_B;
 import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_NOTE_A;
 import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_QUANTITY_B;
 import static seedu.loyaltylift.logic.commands.CommandTestUtil.VALID_STATUS_B_PENDING_DATE;
+import static seedu.loyaltylift.testutil.TypicalCustomers.BENSON;
 import static seedu.loyaltylift.testutil.TypicalOrders.ORDER_B;
 import static seedu.loyaltylift.testutil.TypicalOrders.ORDER_C;
 
@@ -29,35 +30,33 @@ public class OrderTest {
         // null -> returns false
         assertFalse(ORDER_C.isSameOrder(null));
 
-        // different type -> returns false
-        assertFalse(ORDER_C.equals(5));
-
-        // different order -> returns false
-        assertFalse(ORDER_C.equals(ORDER_B));
+        // different name -> returns false
+        Order editedCBenson = new OrderBuilder(ORDER_C).withCustomer(BENSON).build();
+        assertFalse(ORDER_C.isSameOrder(editedCBenson));
 
         // different name -> returns false
         Order editedC = new OrderBuilder(ORDER_C).withName(VALID_NAME_B).build();
-        assertFalse(ORDER_C.equals(editedC));
+        assertFalse(ORDER_C.isSameOrder(editedC));
 
         // different quantity -> returns false
         editedC = new OrderBuilder(ORDER_C).withQuantity(VALID_QUANTITY_B).build();
-        assertFalse(ORDER_C.equals(editedC));
+        assertFalse(ORDER_C.isSameOrder(editedC));
 
-        // different status -> returns false
+        // different status -> returns true
         editedC = new OrderBuilder(ORDER_C).withInitialStatus(VALID_STATUS_B_PENDING_DATE).build();
-        assertFalse(ORDER_C.equals(editedC));
+        assertTrue(ORDER_C.isSameOrder(editedC));
 
-        // different address -> returns false
+        // different address -> returns true
         editedC = new OrderBuilder(ORDER_C).withAddress(VALID_ADDRESS_B).build();
-        assertFalse(ORDER_C.equals(editedC));
+        assertTrue(ORDER_C.isSameOrder(editedC));
 
-        // different created date -> returns false
+        // different created date -> returns true
         editedC = new OrderBuilder(ORDER_C).withCreatedDate(VALID_CREATED_DATE_A).build();
-        assertFalse(ORDER_C.equals(editedC));
+        assertTrue(ORDER_C.isSameOrder(editedC));
 
-        // different note -> returns false
+        // different note -> returns true
         editedC = new OrderBuilder(ORDER_C).withNote(VALID_NOTE_A).build();
-        assertFalse(ORDER_C.equals(editedC));
+        assertTrue(ORDER_C.isSameOrder(editedC));
     }
 
     @Test

--- a/src/test/java/seedu/loyaltylift/model/order/OrderTest.java
+++ b/src/test/java/seedu/loyaltylift/model/order/OrderTest.java
@@ -50,9 +50,9 @@ public class OrderTest {
         editedC = new OrderBuilder(ORDER_C).withAddress(VALID_ADDRESS_B).build();
         assertTrue(ORDER_C.isSameOrder(editedC));
 
-        // different created date -> returns true
+        // different created date -> returns false
         editedC = new OrderBuilder(ORDER_C).withCreatedDate(VALID_CREATED_DATE_A).build();
-        assertTrue(ORDER_C.isSameOrder(editedC));
+        assertFalse(ORDER_C.isSameOrder(editedC));
 
         // different note -> returns true
         editedC = new OrderBuilder(ORDER_C).withNote(VALID_NOTE_A).build();


### PR DESCRIPTION
## Changes
* Update Order::isSameOrder to reflect intended behaviour of same name, quantity and customer being duplicates on the same created date
* Update `addo` and `edito` to check for duplicate order
* Fix parsing of quantity prefix in `edito`

## Note
`isSameOrder` is updated to reflect the current intended behaviour in v1.3 that the orders of the same name and quantity for the same customer cannot exist. While this is not ideal for the end users, we will resolve this feature flaw in future iterations.

Closes #155 
Closes #133 