### PR TITLE
chore: Remove display of last updated and last ordered in UI cards

### DIFF
--- a/src/main/resources/view/Customer/CustomerOrderCard.fxml
+++ b/src/main/resources/view/Customer/CustomerOrderCard.fxml
@@ -1,20 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import java.lang.String?>
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.Cursor?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.Separator?>
-<?import javafx.scene.image.Image?>
-<?import javafx.scene.image.ImageView?>
-<?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.GridPane?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.Region?>
-<?import javafx.scene.layout.RowConstraints?>
-<?import javafx.scene.layout.VBox?>
+<?import java.lang.*?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.image.*?>
+<?import javafx.scene.layout.*?>
 
-<HBox id="cardPane" fx:id="cardPane" stylesheets="@CustomerOrderCard.css" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" stylesheets="@CustomerOrderCard.css" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1">
    <cursor>
       <Cursor fx:constant="DEFAULT" />
    </cursor>
@@ -82,7 +75,7 @@
                <children>
                   <HBox fx:id="statusPlaceholder" alignment="TOP_RIGHT" />
                   <Separator orientation="VERTICAL" visible="false" VBox.vgrow="ALWAYS" />
-                  <Label text="Last Updated: " />
+                  <Label />
                </children>
                <padding>
                   <Insets bottom="10.0" left="5.0" right="5.0" top="10.0" />

--- a/src/main/resources/view/CustomerListCard.fxml
+++ b/src/main/resources/view/CustomerListCard.fxml
@@ -6,7 +6,7 @@
 <?import javafx.scene.image.*?>
 <?import javafx.scene.layout.*?>
 
-<HBox id="cardPane" fx:id="cardPane" stylesheets="@CustomerListCard.css" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" stylesheets="@CustomerListCard.css" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
@@ -56,7 +56,7 @@
          <children>
             <HBox fx:id="accessoryPlaceholder" alignment="TOP_RIGHT" spacing="5.0" />
             <Separator orientation="VERTICAL" visible="false" VBox.vgrow="ALWAYS" />
-            <Label text="Last Ordered: " />
+            <Label />
          </children>
          <padding>
             <Insets bottom="5.0" left="5.0" right="5.0" top="10.0" />


### PR DESCRIPTION
## Changes
* Remove display of `last ordered` in Customer's card
* Remove display of `last updated` in Order's card shown in the Customer's information panel

The displays were not properly implemented in iterations 1.2 and 1.3, hence the removal of these incomplete features for 1.4. 