### PR TITLE
chore: Change caution in UG as cancelled orders can be reverted

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -251,21 +251,18 @@ Here are some recommended features to explore after this tutorial.
   e.g. in `add n/NAME`, `NAME` is a parameter which can be used as `add n/John Doe`.
 
 * Items in square brackets are optional.<br>
-  e.g `n/NAME [t/TAG]` can be used as `n/John Doe t/friend` or as `n/John Doe`.
+  e.g `n/NAME [p/PHONE_NUMBER]` can be used as `n/John Doe p/12341234` or as `n/John Doe`.
 
 * Items in curly brackets are an indication to use one of the given options, separated by the character `|`.
-* e.g. `ct/{ind|ent}` is a parameter that should be used as `ct/ind` or `ct/ent` exactly.
-
-* Items with `…`​ after them can be used multiple times including zero times.<br>
-  e.g. `[t/TAG]…​` can be used as ` ` (i.e. 0 times), `t/friend`, `t/friend t/family` etc.
+  e.g. `ct/{ind|ent}` is a parameter that should be used as `ct/ind` or `ct/ent` exactly.
 
 * Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
 
-* If a parameter is expected only once in the command but you specified it multiple times, only the last occurrence of the parameter will be taken.<br>
+* If a parameter is specified multiple times, only the last occurrence of the parameter will be taken.<br>
   e.g. if you specify `p/12341234 p/56785678`, only `p/56785678` will be taken.
 
-* Extraneous parameters for commands that do not take in parameters (such as `help`, `listc`, `exit` and `clear`) will be ignored.<br>
+* Extraneous parameters for commands that do not take in parameters (such as `help`, `exit` and `clear`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 
 </div>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -215,10 +215,10 @@ An order can be cancelled at any stage of the order. This can be performed with 
 ![result after cancelling order](images/cancelOrderResult.png)
 
 
-Looking at the order status, it is now reflected as 'Cancelled'.
+Looking at the order status, it is now reflected as 'Cancelled'. Once an order is cancelled, its status can no longer be advanced.
 
-<div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
-Once an order is cancelled, the action is irreversible, and the order can no longer revert nor advance! <br />
+<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+If you accidentally cancel an order, you can still revert its status!
 </div>
 
 ### Rewarding your customers


### PR DESCRIPTION
The caution states that a cancelled order can no longer be reverted or advanced. However, reverting actually still works with cancelled orders.

Since this behavior makes sense for undoing an order's cancellation, the UG has been updated to reflect this.

Plus, also removed mentions of tags in the user guide