### PR TITLE
V1.4 fix cancelo

### DIFF
--- a/src/main/java/seedu/loyaltylift/model/order/Status.java
+++ b/src/main/java/seedu/loyaltylift/model/order/Status.java
@@ -68,15 +68,16 @@ public class Status implements Comparable<Status> {
     /**
      * Returns a new {@code Status} with a copy of this StatusUpdate with
      * a new StatusUpdate with a "Cancelled" StatusValue as the next StatusValue.
-     * Should not be called when Status is at Completed stage.
+     * Should not be called when Status is at Completed or Cancelled stage.
      */
     public Status newStatusForCancelledOrder(LocalDate date) {
-        if (getLatestStatus().statusValue.equals(StatusValue.COMPLETED)) {
+        if (getLatestStatus().statusValue.equals(StatusValue.COMPLETED)
+                || getLatestStatus().statusValue.equals(StatusValue.CANCELLED)) {
             throw new IllegalStateException();
         }
 
         ArrayList<StatusUpdate> newStatusUpdates = new ArrayList<>(this.statusUpdates);
-        StatusUpdate statusUpdateCancelled = new StatusUpdate(StatusValue.CANCELLED, LocalDate.now());
+        StatusUpdate statusUpdateCancelled = new StatusUpdate(StatusValue.CANCELLED, date);
         newStatusUpdates.add(statusUpdateCancelled);
 
         return new Status(newStatusUpdates);


### PR DESCRIPTION
## Changes
* Add missing check that the order should not already be cancelled when the user tries to cancel it

Closes #197

Explanation of why this is a functionality bug is mentioned in [the issue #197](https://github.com/AY2223S2-CS2103T-T09-3/tp/issues/197)

