### PR TITLE
fix: Fix cancelled order can be cancelled again

### DIFF
--- a/src/main/java/seedu/loyaltylift/model/order/Status.java
+++ b/src/main/java/seedu/loyaltylift/model/order/Status.java
@@ -68,10 +68,11 @@ public class Status implements Comparable<Status> {
     /**
      * Returns a new {@code Status} with a copy of this StatusUpdate with
      * a new StatusUpdate with a "Cancelled" StatusValue as the next StatusValue.
-     * Should not be called when Status is at Completed stage.
+     * Should not be called when Status is already at completed or cancelled stage.
      */
     public Status newStatusForCancelledOrder(LocalDate date) {
-        if (getLatestStatus().statusValue.equals(StatusValue.COMPLETED)) {
+        if (getLatestStatus().statusValue.equals(StatusValue.COMPLETED)
+                || getLatestStatus().statusValue.equals(StatusValue.CANCELLED)) {
             throw new IllegalStateException();
         }
 


### PR DESCRIPTION
Currently, orders can be cancelled more than once, causing its status history to contain multiple 'Cancelled' status updates.
This behavior also causes another bug: `revo` may not revert a cancelled order's status prior to cancellation.